### PR TITLE
KAN-25 [Security] Restringir búsqueda pública de jugadoras y ocultar emails

### DIFF
--- a/docs/decisions/0002.md
+++ b/docs/decisions/0002.md
@@ -4,7 +4,7 @@ Antes de implementar organizadoras, finanzas, reportes o reparto para Peloteras 
 
 Bloqueantes mínimos:
 - POST /api/onboarding/by-email (cerrado en KAN-24: requiere sesión propia, no usa service role y solo devuelve estado mínimo del usuario autenticado)
-- GET /api/players/search
+- GET /api/players/search (cerrado en KAN-25: requiere sesión, mantiene rate limit y no devuelve email)
 - POST /api/events
 
 Motivo:

--- a/docs/security-admin-api-audit.md
+++ b/docs/security-admin-api-audit.md
@@ -88,7 +88,7 @@ No se reviso Supabase real ni se imprimieron valores de entorno.
 | `POST /api/leads/partners` | Escribe leads con contacto | No | Rate limit + validaciones. | Medio por PII publica. |
 | `POST /api/waitlist` | Email publico | No | Validacion email; RLS public insert. | Bajo. |
 | `POST /api/onboarding/by-email` | Lookup user/profile por email | No | Rate limit; service role. | Bloqueante. |
-| `GET /api/players/search` | Busca jugadoras | No | Rate limit; sin sesion. | Bloqueante/medio por email publico. |
+| `GET /api/players/search` | Busca jugadoras | Si | Rate limit; sesion requerida; respuesta minima sin email. | OK tras KAN-25. |
 | `POST /api/organizer/activate` | Auto-activa admin/organizadora | Si | Usuario propio; rate limit; compromisos + telefono. | Medio/alto. |
 | `POST /api/teams` | Crea equipo | Si | Owner = usuario actual. | Bajo para Full Chocolate. |
 | `POST /api/analytics/events` | Escribe analytics | Opcional | Rate limit; RLS public insert. | Bajo/medio si payload recibe PII. |
@@ -124,6 +124,8 @@ Evidencia: `src/modules/teams/api/handlers/players.search.ts` no exige sesion y 
 Impacto: exposicion publica de emails/perfiles de jugadoras por busqueda de nombre. Para Full Chocolate, esto es incompatible con reportes/usuarios/organizadoras si no se define minimizacion de datos.
 
 Fix sugerido: exigir sesion para buscar jugadoras y devolver solo campos estrictamente necesarios; ocultar email salvo contexto admin/autorizado.
+
+Estado KAN-25: corregido. `GET /api/players/search` mantiene rate limit, exige sesion antes de procesar la busqueda y devuelve solo `id`, `name` y `avatar`; el flujo de equipos ya no consume ni renderiza `email` en sugerencias.
 
 ## Hallazgos medios
 
@@ -232,8 +234,8 @@ Es claro y estable para MVP, pero no auditable desde Supabase. Si Full Chocolate
 ## Fixes pequenos recomendados por PR
 
 1. PR KAN-12A: cerrar enumeracion de usuarios.
-   - Proteger o rediseñar `POST /api/onboarding/by-email`.
-   - Exigir sesion en `GET /api/players/search` y remover `email` del payload publico.
+   - `POST /api/onboarding/by-email` cerrado en KAN-24.
+   - `GET /api/players/search` cerrado en KAN-25: sesion requerida y payload sin `email`.
 
 2. PR KAN-12B: alinear creacion alterna de eventos.
    - Exigir `isAdmin` en `POST /api/events` o descontinuar la ruta.
@@ -269,7 +271,7 @@ Es claro y estable para MVP, pero no auditable desde Supabase. Si Full Chocolate
 
 ## Recomendacion de siguiente PR
 
-El siguiente PR deberia cerrar primero los bloqueantes de exposicion/entrypoints alternos: `POST /api/onboarding/by-email`, `GET /api/players/search` y `POST /api/events`. Son cambios pequenos, acotados y reducen riesgo antes de tocar finanzas o reparto.
+El siguiente PR deberia cerrar el bloqueante de entrypoint alterno `POST /api/events`. KAN-24 ya cerro `POST /api/onboarding/by-email` y KAN-25 cerro `GET /api/players/search`.
 
 ## Comentario sugerido para Jira
 
@@ -289,7 +291,7 @@ Riesgos bloqueantes detectados:
 
 - `POST /api/onboarding/by-email` permite lookup de usuarias/perfil por email sin sesion, usando service role.
 - `POST /api/events` es un entrypoint alterno de creacion de eventos sin `isAdmin` ni reglas completas del admin.
-- `GET /api/players/search` parece exponer emails de jugadoras sin sesion.
+- `GET /api/players/search` parecia exponer emails de jugadoras sin sesion; corregido en KAN-25.
 
 Riesgos medios principales:
 

--- a/src/modules/teams/api/handlers/players.search.ts
+++ b/src/modules/teams/api/handlers/players.search.ts
@@ -1,7 +1,7 @@
 // src/modules/teams/api/handlers/players.search.ts
-import { NextResponse } from 'next/server';
 import { getServerSupabase } from '@src/core/api/supabase.server';
 import { rateLimitByRequest } from '@core/api/rateLimit';
+import { jsonNoStore } from '@core/api/responses';
 
 export async function GET(req: Request) {
   const limited = await rateLimitByRequest(req, {
@@ -12,6 +12,16 @@ export async function GET(req: Request) {
   });
   if (limited) return limited;
 
+  const supabase = await getServerSupabase();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError || !user) {
+    return jsonNoStore({ error: 'Authentication required' }, 401);
+  }
+
   const { searchParams } = new URL(req.url);
   const q = (searchParams.get('q') || '').trim();
   const requestedLimit = Number(searchParams.get('limit') || 10);
@@ -19,16 +29,14 @@ export async function GET(req: Request) {
     ? Math.min(Math.max(Math.floor(requestedLimit), 1), 20)
     : 10;
 
-  if (q.length < 2) return NextResponse.json({ data: [] });
-
-  const supabase = await getServerSupabase();
+  if (q.length < 2) return jsonNoStore({ data: [] });
 
   const { data, error } = await supabase
     .from('users_view') //review this table name
-    .select('id, name, email, avatar')
+    .select('id, name, avatar')
     .ilike('name', `%${q}%`)
     .limit(limit);
 
-  if (error) return NextResponse.json({ error: 'Search failed' }, { status: 500 });
-  return NextResponse.json({ data: data ?? [] }, { headers: { 'Cache-Control': 'no-store' } });
+  if (error) return jsonNoStore({ error: 'Search failed' }, 500);
+  return jsonNoStore({ data: data ?? [] });
 }

--- a/src/modules/teams/ui/PlayerSearchInput.tsx
+++ b/src/modules/teams/ui/PlayerSearchInput.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useDebounce } from '../../../shared/lib/hooks/useDebounce';
 
-type Player = { id: string; name: string; email: string; avatar?: string | null };
+type Player = { id: string; name: string; avatar?: string | null };
 
 interface Props {
   onSelect: (player: Player) => void;
@@ -14,7 +14,7 @@ interface Props {
 export default function PlayerSearchInput({
   onSelect,
   selected,
-  placeholder = 'Buscar por nombre o email…',
+  placeholder = 'Buscar por nombre…',
   minChars = 2,
 }: Props) {
   const [q, setQ] = useState('');
@@ -59,7 +59,7 @@ export default function PlayerSearchInput({
         onChange={(e) => setQ(e.target.value)}
         placeholder={placeholder}
         className="peloteras-form-control h-11 px-3"
-        aria-label="Buscar jugadoras por nombre o email"
+        aria-label="Buscar jugadoras por nombre"
       />
 
       {/* suggestions */}
@@ -86,7 +86,6 @@ export default function PlayerSearchInput({
                 />
                 <div className="flex-1">
                   <div className="text-sm font-medium text-stone-800">{p.name}</div>
-                  <div className="text-xs text-stone-500">{p.email}</div>
                 </div>
                 <span className="text-xs text-stone-600">Agregar</span>
               </button>

--- a/src/modules/teams/ui/TeamCreateModal.tsx
+++ b/src/modules/teams/ui/TeamCreateModal.tsx
@@ -5,7 +5,7 @@ import PlayerSearchInput from './PlayerSearchInput';
 import { createBrowserClient } from '@supabase/ssr'; // si no tienes helper, puedes usar el de supabase-js
 // Si ya tienes un wrapper `utils/supabase/client`, impórtalo de ahí.
 
-type Player = { id: string; name: string; email: string; avatar?: string | null };
+type Player = { id: string; name: string; avatar?: string | null };
 
 interface Props {
   open: boolean;


### PR DESCRIPTION
## Resumen

- Exige sesión en `GET /api/players/search` antes de procesar la búsqueda.
- Mantiene el rate limit existente y minimiza la respuesta a `id`, `name` y `avatar`.
- Actualiza el flujo de equipos para no consumir ni renderizar emails en las sugerencias de jugadoras.
- Documenta KAN-25 como corregido en la auditoría de seguridad y la decisión técnica.

## Causa

El endpoint de búsqueda de jugadoras no validaba sesión y seleccionaba `email` desde `users_view`, lo que permitía exponer datos personales desde una ruta pública.

## Validación

- `./node_modules/.bin/tsc --noEmit`
- `curl -i 'http://localhost:3000/api/players/search?q=ana'` sin sesión: `401 Unauthorized`, `Cache-Control: no-store`, body `{"error":"Authentication required"}`

## Notas

- `pnpm typecheck` no llegó a ejecutar TypeScript por el bloqueo conocido de build scripts de `sharp`; se usó el fallback solicitado.
- `pnpm lint` no llegó a ejecutar lint por purga de módulos sin TTY y `./node_modules/.bin/next lint` no aplica en Next 16 porque interpreta `lint` como directorio.
- No se tocaron pagos, eventos, tickets, check-ins ni schema de base de datos.