### PR TITLE
KAN-13 [DB] Crear schema mínimo de organizadoras y permisos de admin operativa

### DIFF
--- a/docs/decisions/0003-admin-operativa-feature-flags.md
+++ b/docs/decisions/0003-admin-operativa-feature-flags.md
@@ -1,0 +1,69 @@
+# 0003 - Admin operativa con organizadoras y feature flags
+
+## Estado
+
+Aceptada
+
+## Contexto
+
+Peloteras esta incorporando el MVP tecnico Peloteras x Full Chocolate. Las organizadoras que operan eventos necesitan acceso al area admin, pero no todas deben tener las mismas capacidades ni acceso a funciones globales sensibles.
+
+El sistema actual ya usa `isAdmin` como barrera general del admin y `isSuperAdmin` para capacidades globales o mas sensibles. Tambien existen entidades core que no deben reemplazarse en este ticket: `profile`, `event.created_by_id`, `partner_leads`, pagos, tickets y check-ins.
+
+## Decision
+
+Se agrega una capa minima de base de datos con dos tablas:
+
+- `organizers`: representa el estado de negocio de una organizadora. Puede vincularse a `auth.users`, `profile` y a una postulacion previa en `partner_leads`, pero no reemplaza esas tablas.
+- `admin_feature_flags`: representa permisos operativos habilitables por `user_id` para admins no-superadmin.
+
+`isAdmin` se mantiene como acceso general al area admin. `isSuperAdmin` mantiene acceso total y sigue reservando funciones globales sensibles. Las flags de `admin_feature_flags` se usaran en tickets futuros para acotar acciones operativas sin crear un sistema complejo de roles.
+
+Las funciones globales sensibles siguen reservadas para superadmin por ahora:
+
+- usuarios,
+- wallet global,
+- cupones globales,
+- comunicaciones globales,
+- ver todos los eventos.
+
+## Detalles de modelado
+
+`organizers.status` acepta:
+
+- `pilot`,
+- `active`,
+- `paused`,
+- `inactive`.
+
+`organizers.source` acepta:
+
+- `full_chocolate`,
+- `peloteras`,
+- `other`.
+
+`admin_feature_flags` es unica por `user_id` para evitar configuraciones duplicadas por admin operativa. Todas las flags nacen en `false`; este ticket no otorga permisos ni activa admins automaticamente.
+
+Se agregan indices para consultas futuras por `user_id`, `partner_lead_id`, `status` y `source`. Las relaciones opcionales de `organizers` usan `ON DELETE SET NULL` para conservar el registro de negocio si se elimina o desvincula el usuario/perfil/postulacion. Las flags usan `ON DELETE CASCADE` contra `auth.users` porque no deben quedar permisos de usuarios eliminados.
+
+## Seguridad y RLS
+
+Las tablas nuevas nacen con RLS habilitado y una policy minima para `service_role`.
+
+No se agregan policies para `anon` ni `authenticated` en este ticket porque todavia no hay UI, server actions ni route handlers consumiendo estas tablas. Cuando se implemente el uso funcional, cada endpoint debera documentar sesion, rol, ownership y datos sensibles, siguiendo la regla de `docs/decisions/0002.md`.
+
+## Consecuencias
+
+### Positivas
+
+- Se modela la organizadora como entidad de negocio sin romper `profile` ni ownership actual de eventos.
+- Se habilita un camino simple para permisos operativos sin crear roles complejos.
+- Las capacidades sensibles siguen protegidas por `isSuperAdmin`.
+- No se cambia el comportamiento actual de admins existentes.
+
+### Riesgos y pendientes
+
+- Las flags no tienen efecto hasta que los guards de aplicacion las consulten en tickets futuros.
+- Habra que definir policies RLS especificas si alguna lectura o escritura se mueve a cliente autenticado.
+- KAN-15 o tickets posteriores deberan asociar eventos a organizadoras sin reemplazar `event.created_by_id`.
+- La auditoria de cambios de flags queda pendiente para un ticket futuro si se necesita trazabilidad mas detallada.

--- a/supabase/migrations/20260704120000_organizers_admin_feature_flags.sql
+++ b/supabase/migrations/20260704120000_organizers_admin_feature_flags.sql
@@ -1,0 +1,107 @@
+-- KAN-13: organizers and operational admin feature flags
+
+CREATE TABLE IF NOT EXISTS public.organizers (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) ON UPDATE CASCADE ON DELETE SET NULL,
+  profile_id BIGINT REFERENCES public.profile(id) ON UPDATE CASCADE ON DELETE SET NULL,
+  partner_lead_id BIGINT REFERENCES public.partner_leads(id) ON UPDATE CASCADE ON DELETE SET NULL,
+  status TEXT NOT NULL DEFAULT 'pilot',
+  source TEXT NOT NULL DEFAULT 'full_chocolate',
+  zone TEXT,
+  experience_level TEXT,
+  internal_notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CONSTRAINT organizers_status_check
+    CHECK (status IN ('pilot', 'active', 'paused', 'inactive')),
+  CONSTRAINT organizers_source_check
+    CHECK (source IN ('full_chocolate', 'peloteras', 'other'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS organizers_user_id_unique
+  ON public.organizers (user_id)
+  WHERE user_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS organizers_profile_id_unique
+  ON public.organizers (profile_id)
+  WHERE profile_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS organizers_partner_lead_id_unique
+  ON public.organizers (partner_lead_id)
+  WHERE partner_lead_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS organizers_status_idx
+  ON public.organizers (status);
+
+CREATE INDEX IF NOT EXISTS organizers_source_idx
+  ON public.organizers (source);
+
+
+CREATE TABLE IF NOT EXISTS public.admin_feature_flags (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON UPDATE CASCADE ON DELETE CASCADE,
+  can_create_events BOOLEAN NOT NULL DEFAULT false,
+  can_manage_own_events BOOLEAN NOT NULL DEFAULT false,
+  can_view_participants BOOLEAN NOT NULL DEFAULT false,
+  can_manage_payments BOOLEAN NOT NULL DEFAULT false,
+  can_scan_tickets BOOLEAN NOT NULL DEFAULT false,
+  can_manage_finances BOOLEAN NOT NULL DEFAULT false,
+  can_view_reports BOOLEAN NOT NULL DEFAULT false,
+  can_manage_organizers BOOLEAN NOT NULL DEFAULT false,
+  enabled_by UUID REFERENCES auth.users(id) ON UPDATE CASCADE ON DELETE SET NULL,
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CONSTRAINT admin_feature_flags_user_id_key UNIQUE (user_id)
+);
+
+CREATE INDEX IF NOT EXISTS admin_feature_flags_user_id_idx
+  ON public.admin_feature_flags (user_id);
+
+CREATE INDEX IF NOT EXISTS admin_feature_flags_enabled_by_idx
+  ON public.admin_feature_flags (enabled_by)
+  WHERE enabled_by IS NOT NULL;
+
+
+ALTER TABLE public.organizers ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.admin_feature_flags ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'organizers'
+      AND policyname = 'organizers_service_role_all'
+  ) THEN
+    CREATE POLICY organizers_service_role_all
+      ON public.organizers
+      AS PERMISSIVE
+      FOR ALL
+      TO service_role
+      USING (true)
+      WITH CHECK (true);
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'admin_feature_flags'
+      AND policyname = 'admin_feature_flags_service_role_all'
+  ) THEN
+    CREATE POLICY admin_feature_flags_service_role_all
+      ON public.admin_feature_flags
+      AS PERMISSIVE
+      FOR ALL
+      TO service_role
+      USING (true)
+      WITH CHECK (true);
+  END IF;
+END $$;


### PR DESCRIPTION
## Resumen
- Agrega migración Supabase para `organizers` y `admin_feature_flags`.
- Modela estados/fuentes con checks, relaciones a `auth.users`, `profile` y `partner_leads`, e índices básicos.
- Documenta la decisión en `docs/decisions/0003-admin-operativa-feature-flags.md`.

## Validación
- `./node_modules/.bin/tsc --noEmit`
- `npm run lint` (el script termina en 0; Next reporta que no hay ESLint configurado)
- `git diff --cached --check`

## Notas
- No cambia `isAdmin` ni `isSuperAdmin`.
- No toca UI, pagos, eventos, tickets ni check-ins.
- No agrega datos reales ni otorga permisos automáticamente.
- Supabase CLI no está disponible localmente; validar migración con `supabase db reset` o el flujo equivalente del proyecto cuando esté disponible.