### PR TITLE
KAN-15 [Events] Asociar evento con organizadora

### DIFF
--- a/src/modules/admin/api/events/_actions.ts
+++ b/src/modules/admin/api/events/_actions.ts
@@ -70,6 +70,7 @@ function toInsertPayload(
     level: input.levelId,
     is_published: input.isPublished,
     is_featured: isFeatured,
+    organizer_id: input.organizerId,
     created_by_id: userId,
     created_by: createdBy,
   };
@@ -100,6 +101,7 @@ function toUpdatePayload(
     level: input.levelId,
     is_published: input.isPublished,
     is_featured: isFeatured,
+    organizer_id: input.organizerId,
   };
 }
 
@@ -167,6 +169,22 @@ async function assertCanManageEvent(
   if (String(event.created_by_id || '') !== String(user.id || '')) {
     throw new Error('No tienes permisos para gestionar este evento.');
   }
+}
+
+async function assertValidOrganizerSelection(
+  supabase: SupabaseClientLike,
+  organizerId: string | null
+) {
+  if (!organizerId) return;
+
+  const { data, error } = await supabase
+    .from('organizers')
+    .select('id')
+    .eq('id', organizerId)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error('Organizadora no encontrada.');
 }
 
 async function assertEventCanBePublished(
@@ -298,6 +316,7 @@ export async function createEvent(input: EventUpsertInput) {
     ...input,
     paymentMethodIds: paymentMethodSelection.activeOwnedIds,
   });
+  await assertValidOrganizerSelection(adminSupabase, input.organizerId);
 
   const { data: profile, error: profileError } = await adminSupabase
     .from('profile')
@@ -404,6 +423,7 @@ export async function updateEvent(id: string, input: EventUpsertInput) {
   });
 
   await assertCanManageEvent(adminSupabase, id, user);
+  await assertValidOrganizerSelection(adminSupabase, input.organizerId);
   const canManageFeatured = isSuperAdmin(user as any);
   let isFeatured = false;
 

--- a/src/modules/admin/api/organizers/organizers.service.ts
+++ b/src/modules/admin/api/organizers/organizers.service.ts
@@ -2,13 +2,14 @@
 
 import { getAdminSupabase } from '@core/api/supabase.admin';
 import { getServerSupabase } from '@core/api/supabase.server';
-import { isSuperAdmin } from '@shared/lib/auth/isAdmin';
+import { isAdmin, isSuperAdmin } from '@shared/lib/auth/isAdmin';
 import {
   ADMIN_FEATURE_FLAG_KEYS,
   ORGANIZER_STATUSES,
   type AdminFeatureFlagKey,
   type AdminFeatureFlagsState,
   type OrganizerListItem,
+  type OrganizerOption,
   type OrganizersAdminData,
   type OrganizerStatus,
 } from '@modules/admin/model/organizers';
@@ -231,6 +232,67 @@ export async function getOrganizersAdminData(): Promise<OrganizersAdminData> {
     organizers: organizerItems,
     partnerLeads: leadItems,
   };
+}
+
+export async function getOrganizerOptionsForEventForm(): Promise<OrganizerOption[]> {
+  const supabase = await getServerSupabase();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user || !isAdmin(user as any)) {
+    throw new Error('No tienes permisos para gestionar eventos.');
+  }
+
+  const admin = getAdminSupabase();
+  const { data, error } = await admin
+    .from('organizers')
+    .select('id,user_id,profile_id,partner_lead_id,status,source,zone,experience_level,internal_notes,created_at,updated_at')
+    .order('created_at', { ascending: false });
+
+  if (error) throw new Error(error.message);
+
+  const organizers = (data ?? []) as OrganizerRow[];
+  const partnerLeadIds = organizers
+    .map((organizer) => Number(organizer.partner_lead_id))
+    .filter((id) => Number.isInteger(id) && id > 0);
+  const userIds = organizers.map((organizer) => organizer.user_id).filter((id): id is string => Boolean(id));
+
+  const [leadsResult, profilesByUserId] = await Promise.all([
+    partnerLeadIds.length
+      ? admin
+          .from('partner_leads')
+          .select('id,contact_name,contact_email,organization_name,location_label')
+          .in('id', partnerLeadIds)
+      : Promise.resolve({ data: [], error: null }),
+    getProfileByUserIds(userIds),
+  ]);
+
+  if (leadsResult.error) throw new Error(leadsResult.error.message);
+
+  type OrganizerLeadOptionRow = Pick<
+    PartnerLeadRow,
+    'id' | 'contact_name' | 'contact_email' | 'organization_name' | 'location_label'
+  >;
+  const leadsById = new Map<number, OrganizerLeadOptionRow>();
+  ((leadsResult.data ?? []) as OrganizerLeadOptionRow[]).forEach((lead) => {
+    leadsById.set(lead.id, lead);
+  });
+
+  return organizers.map((organizer) => {
+    const lead = organizer.partner_lead_id ? leadsById.get(organizer.partner_lead_id) : null;
+    const profile = organizer.user_id ? profilesByUserId.get(organizer.user_id) : null;
+    const leadName = normalizeText(lead?.organization_name) || normalizeText(lead?.contact_name);
+    const profileName = normalizeText(profile?.username);
+
+    return {
+      id: organizer.id,
+      displayName: leadName || profileName || `Organizadora ${organizer.id.slice(0, 8)}`,
+      status: organizer.status,
+      contactEmail: normalizeText(lead?.contact_email),
+      zone: normalizeText(lead?.location_label) || normalizeText(organizer.zone),
+    };
+  });
 }
 
 export async function createOrganizerFromPartnerLead(leadId: number) {

--- a/src/modules/admin/model/eventForm.ts
+++ b/src/modules/admin/model/eventForm.ts
@@ -19,6 +19,7 @@ export type EventUpsertInput = {
   levelId: number;
   featureIds: number[];
   paymentMethodIds: number[];
+  organizerId: string | null;
   isPublished: boolean;
   isFieldReservedConfirmed: boolean;
   isFeatured: boolean;
@@ -60,6 +61,17 @@ function normalizeDistrict(value: FormDataEntryValue | null) {
   return String(district || '').trim();
 }
 
+function parseNullableUuid(value: FormDataEntryValue | null) {
+  const raw = String(value || '').trim();
+  if (!raw) return null;
+
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(raw)) {
+    return raw;
+  }
+
+  throw new Error('Organizadora invalida.');
+}
+
 export function parseEventFormData(fd: FormData): EventUpsertInput {
   const rawStartTime = String(fd.get('startTime') || '').trim();
   const rawEndTime = String(fd.get('endTime') || '').trim();
@@ -82,6 +94,7 @@ export function parseEventFormData(fd: FormData): EventUpsertInput {
     levelId: parseNumber(fd.get('levelId'), 1),
     featureIds: parseNumberList(fd.getAll('featureIds')),
     paymentMethodIds: parseNumberList(fd.getAll('paymentMethodIds')),
+    organizerId: parseNullableUuid(fd.get('organizerId')),
     isPublished: parseBoolean(fd.get('isPublished')),
     isFieldReservedConfirmed: parseBoolean(fd.get('isFieldReservedConfirmed')),
     isFeatured: parseBoolean(fd.get('isFeatured')),

--- a/src/modules/admin/model/organizers.ts
+++ b/src/modules/admin/model/organizers.ts
@@ -38,6 +38,14 @@ export type OrganizerListItem = {
   flags: AdminFeatureFlagsState | null;
 };
 
+export type OrganizerOption = {
+  id: string;
+  displayName: string;
+  status: OrganizerStatus;
+  contactEmail: string | null;
+  zone: string | null;
+};
+
 export type PartnerLeadListItem = {
   id: number;
   displayName: string;

--- a/src/modules/admin/ui/events/EventFormComponent.tsx
+++ b/src/modules/admin/ui/events/EventFormComponent.tsx
@@ -45,6 +45,7 @@ import {
   partitionPaymentMethodSelection,
 } from '@shared/lib/paymentMethodSelection';
 import UsersRichTextEditor from '@modules/admin/ui/users/UsersRichTextEditor';
+import type { OrganizerOption } from '@modules/admin/model/organizers';
 
 type SubmitResult = {
   eventId?: string | number;
@@ -80,6 +81,7 @@ type EventCreateDraftSnapshot = {
     isFieldReservedConfirmed: boolean;
     selectedFeatureIds: number[];
     selectedPaymentMethodIds: number[];
+    organizerId: string | null;
   };
 };
 
@@ -102,6 +104,7 @@ type Props = {
     levelId: number;
     featureIds: number[];
     paymentMethodIds: number[];
+    organizerId: string | null;
     isPublished: boolean;
     isFieldReservedConfirmed: boolean;
     isFeatured: boolean;
@@ -110,6 +113,7 @@ type Props = {
   levels: CatalogOption[];
   features?: CatalogOption[];
   paymentMethods?: PaymentMethodOption[];
+  organizerOptions?: OrganizerOption[];
   onSubmit: (form: FormData) => Promise<void | SubmitResult>;
   submitLabel: string;
   canManageFeatured?: boolean;
@@ -329,6 +333,7 @@ const EventForm = ({
   levels,
   features = [],
   paymentMethods = [],
+  organizerOptions = [],
   onSubmit,
   submitLabel,
   canManageFeatured = false,
@@ -413,6 +418,10 @@ const EventForm = ({
         input.map((value) => Number(value)).filter((value) => Number.isInteger(value) && value > 0)
       )
     );
+  });
+  const [selectedOrganizerId, setSelectedOrganizerId] = useState(() => {
+    const initialId = String(initial?.organizerId || '').trim();
+    return organizerOptions.some((option) => option.id === initialId) ? initialId : '';
   });
   const [paymentMethodCatalog, setPaymentMethodCatalog] = useState<PaymentMethodOption[]>(() =>
     normalizePaymentMethodCatalog(paymentMethods)
@@ -569,6 +578,18 @@ const EventForm = ({
         };
       }),
     [paymentMethodCatalog]
+  );
+  const organizerSelectOptions = useMemo(
+    () =>
+      organizerOptions.map((option) => {
+        const statusText = option.status ? ` · ${option.status}` : '';
+        const zoneText = option.zone ? ` · ${option.zone}` : '';
+        return {
+          value: option.id,
+          label: `${option.displayName}${statusText}${zoneText}`,
+        };
+      }),
+    [organizerOptions]
   );
   const isCreateMode = useMemo(() => submitLabel.trim().toLowerCase() === 'crear', [submitLabel]);
   const activeCreateStep = CREATE_EVENT_STEPS[createStep - 1];
@@ -774,6 +795,7 @@ const EventForm = ({
         isFieldReservedConfirmed,
         selectedFeatureIds,
         selectedPaymentMethodIds,
+        organizerId: selectedOrganizerId || null,
       },
     };
   }
@@ -867,6 +889,7 @@ const EventForm = ({
     setIsFieldReservedConfirmed(Boolean(snapshot.state.isFieldReservedConfirmed));
     setSelectedFeatureIds(snapshot.state.selectedFeatureIds);
     setSelectedPaymentMethodIds(snapshot.state.selectedPaymentMethodIds);
+    setSelectedOrganizerId(snapshot.state.organizerId || '');
   }
 
   function handleResetCreateDraft() {
@@ -1592,6 +1615,7 @@ const EventForm = ({
     selectedEventTypeId,
     selectedFeatureIds,
     selectedLevelId,
+    selectedOrganizerId,
     selectedPaymentMethodIds,
     startTime,
   ]);
@@ -2224,6 +2248,40 @@ const EventForm = ({
                 onMethodsChange={handleInlinePaymentMethodsChange}
                 onMethodSaved={handleInlinePaymentMethodSaved}
               />
+
+              <label className="w-full">
+                <div className="mb-1 text-sm font-semibold text-slate-700">
+                  Organizadora de negocio
+                </div>
+                {organizerSelectOptions.length > 0 ? (
+                  <>
+                    <select
+                      name="organizerId"
+                      value={selectedOrganizerId}
+                      onChange={(event) => setSelectedOrganizerId(event.currentTarget.value)}
+                      className={FLOW_NATIVE_SELECT_CLASS}
+                    >
+                      <option value="">Sin organizadora asociada</option>
+                      {organizerSelectOptions.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                    <p className="mt-1 text-xs text-slate-500">
+                      Esta relación es interna para administración y no cambia la dueña técnica del
+                      evento.
+                    </p>
+                  </>
+                ) : (
+                  <>
+                    <input type="hidden" name="organizerId" value="" readOnly />
+                    <div className="rounded-[16px] border border-slate-200 bg-slate-50 px-4 py-3 text-xs font-medium text-slate-600">
+                      No hay organizadoras disponibles para asociar.
+                    </div>
+                  </>
+                )}
+              </label>
 
               <div className="w-full">
                 <div className="mb-1 text-sm font-semibold text-slate-700">Features</div>

--- a/src/modules/admin/ui/events/screens/EditEventScreen.tsx
+++ b/src/modules/admin/ui/events/screens/EditEventScreen.tsx
@@ -15,6 +15,7 @@ import {
   extractEventDescriptionHtml,
   extractEventDescriptionText,
 } from '@shared/lib/eventDescription';
+import { getOrganizerOptionsForEventForm } from '@modules/admin/api/organizers/organizers.service';
 
 export default async function EditEventScreen({ id }: { id: string }) {
   const supabase = await getServerSupabase();
@@ -29,8 +30,15 @@ export default async function EditEventScreen({ id }: { id: string }) {
 
   const event = await getEventById(id);
   if (!event) redirect('/admin/events');
-  const [catalogs, featuresRes, eventFeaturesRes, paymentMethodsRes, eventPaymentMethodsRes, participants] =
-    await Promise.all([
+  const [
+    catalogs,
+    featuresRes,
+    eventFeaturesRes,
+    paymentMethodsRes,
+    eventPaymentMethodsRes,
+    participants,
+    organizerOptions,
+  ] = await Promise.all([
       getEventCatalogs(),
       supabase.from('features').select('id,name').order('name', { ascending: true }),
       supabase.from('eventFeatures').select('feature').eq('event', id),
@@ -42,6 +50,7 @@ export default async function EditEventScreen({ id }: { id: string }) {
         .order('created_at', { ascending: false }),
       supabase.from('eventPaymentMethod').select('paymentMethod').eq('event', id),
       getApprovedParticipantsByEventId(id),
+      getOrganizerOptionsForEventForm(),
     ]);
 
   if (featuresRes.error) throw new Error(featuresRes.error.message);
@@ -147,10 +156,12 @@ export default async function EditEventScreen({ id }: { id: string }) {
           levelId: event.level,
           featureIds: selectedFeatureIds,
           paymentMethodIds: selectedPaymentMethodIds,
+          organizerId: event.organizer_id ?? null,
           isPublished: event.is_published !== false,
           isFieldReservedConfirmed: parseStoredBoolean(descriptionObject?.field_reserved_confirmed),
           isFeatured: Boolean(event.is_featured),
         }}
+        organizerOptions={organizerOptions}
         canManageFeatured={canManageFeatured}
         postEditAnnouncement={{
           eventId: id,

--- a/src/modules/admin/ui/events/screens/NewEventScreen.tsx
+++ b/src/modules/admin/ui/events/screens/NewEventScreen.tsx
@@ -13,6 +13,7 @@ import {
   extractEventDescriptionText,
 } from '@shared/lib/eventDescription';
 import { redirect } from 'next/navigation';
+import { getOrganizerOptionsForEventForm } from '@modules/admin/api/organizers/organizers.service';
 
 type Props = {
   templateId?: string;
@@ -29,7 +30,7 @@ export default async function NewEventScreen({ templateId }: Props) {
 
   const canManageFeatured = isSuperAdmin(user as any);
   const normalizedTemplateId = String(templateId || '').trim();
-  const [catalogs, featuresRes, paymentMethodsRes] = await Promise.all([
+  const [catalogs, featuresRes, paymentMethodsRes, organizerOptions] = await Promise.all([
     getEventCatalogs(),
     supabase.from('features').select('id,name').order('name', { ascending: true }),
     supabase
@@ -38,6 +39,7 @@ export default async function NewEventScreen({ templateId }: Props) {
       .eq('created_by', user?.id || '')
       .order('is_active', { ascending: false })
       .order('created_at', { ascending: false }),
+    getOrganizerOptionsForEventForm(),
   ]);
 
   if (featuresRes.error) {
@@ -94,6 +96,7 @@ export default async function NewEventScreen({ templateId }: Props) {
         levelId: number;
         featureIds: number[];
         paymentMethodIds: number[];
+        organizerId: string | null;
         isPublished: boolean;
         isFieldReservedConfirmed: boolean;
         isFeatured: boolean;
@@ -160,6 +163,7 @@ export default async function NewEventScreen({ templateId }: Props) {
         levelId: Number(templateEvent.level || catalogs.levels[0]?.id || 1),
         featureIds: selectedFeatureIds,
         paymentMethodIds: selectedPaymentMethodIds,
+        organizerId: templateEvent.organizer_id ?? null,
         isPublished: templateEvent.is_published !== false,
         isFieldReservedConfirmed: parseStoredBoolean(descriptionObject?.field_reserved_confirmed),
         isFeatured: Boolean(templateEvent.is_featured),
@@ -182,6 +186,7 @@ export default async function NewEventScreen({ templateId }: Props) {
   const initialValues = {
     featureIds: [],
     paymentMethodIds: [],
+    organizerId: null,
     eventTypeId: selectableEventTypes[0]?.id ?? 1,
     levelId: catalogs.levels[0]?.id ?? 1,
     ...templateInitial,
@@ -204,6 +209,7 @@ export default async function NewEventScreen({ templateId }: Props) {
         levels={catalogs.levels}
         features={features}
         paymentMethods={paymentMethods}
+        organizerOptions={organizerOptions}
         initial={initialValues}
         canManageFeatured={canManageFeatured}
         successRedirectTo="/admin/events"

--- a/supabase/migrations/20260704123000_event_organizer_link.sql
+++ b/supabase/migrations/20260704123000_event_organizer_link.sql
@@ -1,0 +1,10 @@
+-- KAN-15: optional business organizer link for events
+
+ALTER TABLE public.event
+  ADD COLUMN IF NOT EXISTS organizer_id UUID REFERENCES public.organizers(id)
+    ON UPDATE CASCADE
+    ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS event_organizer_id_idx
+  ON public.event (organizer_id)
+  WHERE organizer_id IS NOT NULL;


### PR DESCRIPTION
## Resumen
- Agrega organizer_id nullable en event con FK a organizers e indice para consultas por organizadora.
- Conecta crear/editar evento admin con selector opcional de organizadora.
- Valida server-side que la organizadora seleccionada exista antes de guardar.

## Validacion
- pnpm typecheck: bloqueado por ERR_PNPM_IGNORED_BUILDS sharp antes de ejecutar TypeScript.
- ./node_modules/.bin/tsc --noEmit: OK.
- pnpm lint: bloqueado por ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY antes de ejecutar lint.
- ./node_modules/.bin/next lint: no disponible en esta version de Next; interpreta lint como directorio.