### PR TITLE
Improve home landing player focus

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import CardEventList from '@modules/events/ui/cardEvents/CardEventList';
 import AlliesCarouselEntry from '@modules/home/ui/AlliesCarouselEntry';
 import LandingGrowthBlocks from '@modules/home/ui/LandingGrowthBlocks';
 import HomeReveal from '@modules/home/ui/HomeReveal';
+import HomeHowItWorksSection from '@modules/home/ui/HomeHowItWorksSection';
 import MainSection from '@modules/home/ui/MainSection';
 import { homeAllies } from '@modules/home/ui/homeContent';
 
@@ -85,6 +86,16 @@ export default async function Index() {
       <div className="flex w-full flex-col gap-8 pb-8 sm:gap-10 sm:pb-10 lg:gap-12 lg:pb-12">
         <MainSection />
 
+        <HomeHowItWorksSection />
+
+        <section className="home-scroll-target w-full" id="eventos-destacados">
+          <HomeReveal className="site-shell">
+            <CardEventList />
+          </HomeReveal>
+        </section>
+
+        <LandingGrowthBlocks />
+
         {homeAllies.length > 0 && (
           <section className="home-scroll-target w-full" id="aliadxs">
             <HomeReveal className="site-shell">
@@ -110,14 +121,6 @@ export default async function Index() {
             </HomeReveal>
           </section>
         )}
-
-        <section className="home-scroll-target w-full" id="eventos-destacados">
-          <HomeReveal className="site-shell">
-            <CardEventList />
-          </HomeReveal>
-        </section>
-
-        <LandingGrowthBlocks />
       </div>
     </>
   );

--- a/src/modules/events/ui/cardEvents/CardEventList.tsx
+++ b/src/modules/events/ui/cardEvents/CardEventList.tsx
@@ -52,7 +52,7 @@ const CardEventList = async ({ previewCount, showViewAll = true }: CardEventList
             Eventos destacados
           </p>
           <h2 className="mt-3 font-eastman-extrabold text-4xl leading-[1.02] text-slate-900 sm:text-5xl lg:text-[3rem]">
-            Partidos y pichangas para volver a la cancha.
+            Pichangas y partidos para volver a la cancha
           </h2>
           <p className="mt-4 text-base leading-8 text-slate-600 sm:text-lg">
             Explora las próximas pichangas en Peloteras y encuentra una oportunidad para jugar,

--- a/src/modules/events/ui/cardEvents/FeaturedEventsClient.tsx
+++ b/src/modules/events/ui/cardEvents/FeaturedEventsClient.tsx
@@ -83,7 +83,7 @@ export default function FeaturedEventsClient({ events, previewCount }: Props) {
       {!visibleEvents.length ? (
         <div className="premium-card px-6 py-6 text-sm text-slate-600">
           {timeFilter === 'upcoming'
-            ? 'Aún no hay fechas destacadas próximas.'
+            ? 'Aún no hay fechas destacadas próximas. Explora todos los eventos o vuelve pronto para encontrar nuevas pichangas.'
             : 'Aún no hay fechas destacadas finalizadas.'}
         </div>
       ) : (

--- a/src/modules/home/ui/HomeHowItWorksSection.tsx
+++ b/src/modules/home/ui/HomeHowItWorksSection.tsx
@@ -1,0 +1,50 @@
+import HomeReveal from '@modules/home/ui/HomeReveal';
+
+const steps = [
+  {
+    title: 'Encuentra una pichanga',
+    description: 'Revisa eventos disponibles por fecha, zona, horario, nivel y cupos.',
+  },
+  {
+    title: 'Elige dónde sumarte',
+    description: 'Mira los detalles del evento y decide si va contigo antes de inscribirte.',
+  },
+  {
+    title: 'Llega y juega',
+    description: 'Vuelve a la cancha, conoce nuevas peloteras y encuentra más espacios para jugar.',
+  },
+];
+
+export default function HomeHowItWorksSection() {
+  return (
+    <section className="home-scroll-target w-full" id="como-funciona">
+      <HomeReveal className="site-shell">
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,0.82fr)_minmax(0,1.18fr)] lg:items-start">
+          <div className="max-w-[34rem]">
+            <p className="text-sm font-semibold uppercase tracking-[0.18em] text-mulberry/75">
+              Cómo funciona
+            </p>
+            <h2 className="mt-3 font-eastman-extrabold text-4xl leading-[1.02] text-slate-900 sm:text-5xl lg:text-[3rem]">
+              Pasar de querer jugar a estar en la cancha debería ser simple.
+            </h2>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-3">
+            {steps.map((step, index) => (
+              <article
+                key={step.title}
+                className="premium-card flex h-full flex-col px-5 py-5"
+              >
+                <span className="font-eastman-extrabold text-2xl leading-none text-mulberry/30">
+                  {String(index + 1).padStart(2, '0')}
+                </span>
+                <h3 className="mt-4 text-lg font-semibold text-slate-900">{step.title}</h3>
+                <p className="mt-2 text-base leading-7 text-slate-500">{step.description}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </HomeReveal>
+    </section>
+  );
+}

--- a/src/modules/home/ui/LandingGrowthBlocks.tsx
+++ b/src/modules/home/ui/LandingGrowthBlocks.tsx
@@ -18,24 +18,25 @@ export default function LandingGrowthBlocks() {
                 Para jugadoras
               </p>
               <h2 className="mt-3 font-eastman-extrabold text-4xl leading-[1.02] text-slate-900 sm:text-5xl lg:text-[3rem]">
-                Más pichangas para volver a la cancha.
+                Para quienes quieren jugar más seguido
               </h2>
               <p className="mt-4 text-lg leading-8 text-slate-600">
-                Encuentra pichangas con toda la información que necesitas para decidir si te sumas.
-                Sin depender de chats ni grupos de WhatsApp.
+                Encuentra pichangas con la información que necesitas para decidir si te sumas:
+                fecha, sede, horario, costo, cupos e indicaciones. Sin depender solo de chats o
+                invitaciones sueltas.
               </p>
               <div className="mt-7 flex flex-wrap gap-3">
                 <Link
-                  href="/signUp?source=home-jugadoras"
+                  href="/events"
                   className="home-button-micro inline-flex h-12 items-center rounded-full bg-mulberry px-6 text-base font-semibold text-white shadow-[0_18px_36px_-28px_rgba(84,8,111,0.9)] hover:bg-[#470760]"
                 >
-                  Crear mi cuenta
+                  Explorar eventos
                 </Link>
                 <Link
-                  href="/events"
+                  href="/signUp?source=home-jugadoras"
                   className="home-button-micro premium-outline inline-flex h-12 items-center rounded-full px-6 text-base font-semibold text-slate-700 hover:bg-white"
                 >
-                  Explorar eventos
+                  Crear mi cuenta
                 </Link>
               </div>
             </div>
@@ -67,11 +68,15 @@ export default function LandingGrowthBlocks() {
           <div className="rounded-[2rem] bg-[#f7f1fb] px-6 py-8 sm:px-8 sm:py-10 lg:px-10 lg:py-12">
             <div className="max-w-[34rem]">
               <p className="text-sm font-semibold uppercase tracking-[0.18em] text-mulberry/75">
-                Para administradoras de eventos
+                Para organizadoras
               </p>
               <h2 className="mt-3 font-eastman-extrabold text-4xl leading-[1.02] text-slate-900 sm:text-5xl lg:text-[3rem]">
-                Las herramientas para organizar fútbol con más orden.
+                Para quienes quieren organizar fútbol
               </h2>
+              <p className="mt-4 max-w-[42rem] text-lg leading-8 text-slate-600">
+                Publica tus pichangas, ordena la información del evento y facilita que más
+                jugadoras encuentren dónde sumarse.
+              </p>
             </div>
 
             <div className="mt-8 grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
@@ -92,7 +97,7 @@ export default function LandingGrowthBlocks() {
 
             <div className="mt-7">
               <OrganizerEntryLink className="home-button-micro inline-flex h-12 items-center rounded-full bg-mulberry px-6 text-base font-semibold text-white shadow-[0_18px_36px_-28px_rgba(84,8,111,0.9)] hover:bg-[#470760]">
-                Activar perfil organizadora
+                Quiero organizar
               </OrganizerEntryLink>
             </div>
           </div>
@@ -157,10 +162,11 @@ export default function LandingGrowthBlocks() {
                   Súmate
                 </p>
                 <h2 className="mt-3 font-eastman-extrabold text-4xl leading-[1.02] text-slate-900 sm:text-5xl lg:text-[3rem]">
-                  Haz que tu próximo partido te encuentre en Peloteras.
+                  Encuentra tu próxima pichanga en Peloteras
                 </h2>
                 <p className="mt-4 text-lg leading-8 text-slate-900/80">
-                  Anótate a tu próxima pichanga o abre la tuya para tu comunidad. Las dos cuentan.
+                  Explora eventos disponibles o crea el tuyo para que más jugadoras puedan sumarse.
+                  Más peloteras, más fútbol.
                 </p>
               </div>
 
@@ -171,12 +177,11 @@ export default function LandingGrowthBlocks() {
                 >
                   Ver eventos
                 </Link>
-                <Link
-                  href="/signUp?source=home-final-cta"
+                <OrganizerEntryLink
                   className="home-button-micro inline-flex h-12 items-center justify-center rounded-full border border-slate-900/25 bg-slate-900/[0.10] px-6 text-base font-semibold text-slate-900 hover:bg-slate-900/20"
                 >
-                  Crear mi cuenta
-                </Link>
+                  Quiero organizar
+                </OrganizerEntryLink>
               </div>
             </div>
           </div>

--- a/src/modules/home/ui/MainSection.tsx
+++ b/src/modules/home/ui/MainSection.tsx
@@ -38,8 +38,8 @@ export default async function MainSection() {
             </h1>
 
             <p className="mt-5 max-w-[40rem] text-[17px] leading-[1.55] text-slate-600 sm:text-[20px] sm:leading-[1.6]">
-              En Peloteras puedes jugar fútbol, encontrar eventos deportivos, organizar los
-              tuyos, conectar con más mujeres y personas de la diversidad.
+              Explora pichangas y eventos de fútbol para mujeres y disidencias. Revisa fecha,
+              zona, nivel y cupos disponibles para sumarte sin depender de grupos cerrados.
             </p>
 
             <div className="mt-8 flex w-full min-w-0 flex-col gap-3 sm:flex-row sm:flex-wrap">
@@ -63,7 +63,7 @@ export default async function MainSection() {
                 </svg>
               </Link>
               <OrganizerEntryLink className="group home-button-micro premium-outline inline-flex min-h-12 w-full min-w-0 max-w-full items-center justify-center gap-2 rounded-full px-5 py-3 text-[15px] font-semibold text-slate-700 hover:border-slate-300 hover:bg-white sm:h-12 sm:w-auto sm:px-7 sm:py-0 sm:text-base">
-                <span className="min-w-0 text-center leading-tight">Quiero organizar una pichanga</span>
+                <span className="min-w-0 text-center leading-tight">Quiero organizar</span>
                 <span
                   className="h-1.5 w-1.5 rounded-full bg-primary transition-transform duration-300 group-hover:scale-125"
                   aria-hidden="true"

--- a/src/modules/home/ui/homeContent.ts
+++ b/src/modules/home/ui/homeContent.ts
@@ -62,27 +62,27 @@ export const adminBenefits: HomeCard[] = [
   {
     title: 'Publica con información completa',
     description:
-      'Agrega fecha, hora, lugar, cupos, precio e indicaciones en un solo flujo para que todo quede claro desde el inicio.',
+      'Agrega fecha, hora, lugar, cupos, precio e indicaciones para que las jugadoras sepan exactamente cómo sumarse.',
   },
   {
     title: 'Llega a más jugadoras interesadas',
     description:
-      'Tu evento vive dentro de una comunidad que ya está buscando dónde jugar, inscribirse y conectar con más fútbol.',
+      'Tu evento aparece en una comunidad que está buscando dónde jugar.',
   },
   {
-    title: 'Gestiona inscripciones con confianza',
+    title: 'Gestiona inscripciones con más orden',
     description:
-      'Haz seguimiento de participantes y organiza cada fecha con más orden y menos fricción operativa.',
+      'Haz seguimiento de participantes y organiza cada fecha con menos fricción.',
   },
   {
     title: 'Valida ingresos con QR',
     description:
-      'Acelera el check-in el día del evento con un sistema pensado para confirmar entradas de forma más rápida.',
+      'Confirma entradas de forma rápida el día del evento.',
   },
   {
     title: 'Reutiliza eventos como plantilla',
     description:
-      'Si organizas seguido, puedes tomar una fecha anterior como base y lanzar nuevas convocatorias sin empezar de cero.',
+      'Si organizas seguido, crea nuevas fechas sin empezar desde cero.',
   },
 ];
 


### PR DESCRIPTION
## Summary
- Adds a new home how-it-works section focused on joining pichangas
- Moves allies below events/growth content so featured events appear earlier
- Updates landing copy for player-first messaging while keeping organizer paths secondary

## Validation
- ./node_modules/.bin/tsc --noEmit
- git diff --check

Note: FAQ was intentionally left out to keep this PR small, per the request guidance.