### PR TITLE
[codex] Fix signup account completion flow

### DIFF
--- a/src/modules/auth/ui/signup/SignupClient.tsx
+++ b/src/modules/auth/ui/signup/SignupClient.tsx
@@ -110,7 +110,6 @@ export default function SignupClient() {
   const [selectedLevel, setSelectedLevel] = useState<string | number | null>(null);
 
   const [userId, setUserId] = useState<string | null>(null);
-  const [isCheckingUsername, setIsCheckingUsername] = useState(false);
 
   const signupRedirectTo = useMemo(() => {
     return authCallbackUrl({
@@ -911,33 +910,7 @@ export default function SignupClient() {
                   message: `Máximo ${USERNAME_MAX_LENGTH} caracteres`,
                 },
                 validate: validateUsernameForForm,
-                onBlur: async (e) => {
-                  const rawValue = String(e?.target?.value ?? '').trim();
-                  const usernameValidation = validateUsername(rawValue);
-                  if (usernameValidation.ok === false) {
-                    setError('username', {
-                      type: 'manual',
-                      message: usernameValidation.message,
-                    });
-                    return;
-                  }
-                  setIsCheckingUsername(true);
-                  const result = await checkUsernameAvailabilityAction(
-                    usernameValidation.value,
-                    userId ?? undefined
-                  );
-                  setIsCheckingUsername(false);
-                  if (!result.available) {
-                    setError('username', {
-                      type: 'manual',
-                      message:
-                        result.message ||
-                        (result.reason === 'error'
-                          ? 'No se pudo validar el nombre ahora.'
-                          : 'El nombre de usuario ya está en uso.'),
-                    });
-                    return;
-                  }
+                onChange: () => {
                   clearErrors('username');
                 },
               })}
@@ -947,9 +920,6 @@ export default function SignupClient() {
               errorText={errors.username?.message as string | undefined}
             />
             <p className="text-xs text-slate-500 -mt-2">Máximo 15 caracteres, sin espacios.</p>
-            {isCheckingUsername && (
-              <p className="text-xs text-slate-500 -mt-2">Verificando disponibilidad...</p>
-            )}
 
             <label className="w-full">
               <div className="mb-1">
@@ -980,7 +950,7 @@ export default function SignupClient() {
               />
             </label>
 
-            {isGoogleOnboarding && (
+            {!isIdentityConfirmed && (
               <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
                 <label className="flex items-start gap-3">
                   <input

--- a/src/modules/users/actions/createProfile.actions.ts
+++ b/src/modules/users/actions/createProfile.actions.ts
@@ -77,6 +77,15 @@ function isProfileUserFkError(message: string) {
 function isProfileUsernameConflictError(message: string) {
   return (
     message.includes('profile_username_key') ||
+    message.includes('username already exists') ||
+    message.includes('username already taken') ||
+    message.includes('username is already taken') ||
+    message.includes('nombre de usuario ya esta en uso') ||
+    message.includes('nombre de usuario ya existe') ||
+    (message.includes('username') && message.includes('already exists')) ||
+    (message.includes('username') && message.includes('already registered')) ||
+    (message.includes('username') && message.includes('duplicat')) ||
+    (message.includes('username') && message.includes('unique')) ||
     message.includes('duplicate key value violates unique constraint') ||
     (message.includes('unique') && message.includes('username'))
   );
@@ -448,10 +457,13 @@ export async function completeOnboardingProfileAction(
         }
 
         const shouldUseDirectFallback =
-          isProfileUserFkError(createMessage) ||
-          isUserMissingError(createMessage) ||
-          isTransientProfileBackendError(createMessage) ||
-          isTransientProfileBackendError(message);
+          !isProfileUsernameValidationError(createMessage) &&
+          (isProfileUserFkError(createMessage) ||
+            isUserMissingError(createMessage) ||
+            isTransientProfileBackendError(createMessage) ||
+            isTransientProfileBackendError(message) ||
+            createMessage.includes('http ') ||
+            message.includes('http '));
 
         if (!shouldUseDirectFallback) {
           throw createError;


### PR DESCRIPTION
## Qué cambia

- Lleva a main solo el fix 37b0703 que ya estaba en dev para el flujo de registro y actualización/completado de cuenta.
- El formulario de signup deja de depender de la validación de username en blur, para evitar que el usuario quede bloqueado esperando foco/salida del campo.
- La confirmación de identidad se muestra cuando aún falta confirmarla, alineando el UI con la condición que habilita continuar.
- La acción de perfil reconoce más variantes de conflicto de username y permite fallback directo ante errores backend/transitorios sin ocultar validaciones reales.

## Por qué

En dev, el fix corrigió el bloqueo del flujo de registro/completado de cuenta: el botón continuar podía quedar deshabilitado o el backend podía devolver errores genéricos durante la creación/actualización del perfil.

## Alcance

Solo se cherry-pickeó el commit 37b07035a8b9b83006e1cd310a3299f5301b9dd2 desde dev sobre main. No se incluyen cambios de organizadoras, eventos, docs, seguridad u otros commits de dev.

## Validación

- pnpm typecheck intentado: falla por el bloqueo conocido ERR_PNPM_IGNORED_BUILDS de sharp@0.34.5.
- ./node_modules/.bin/tsc --noEmit pasa correctamente.