### PR TITLE
Solicitar celular y fecha de nacimiento para acciones de eventos

### DIFF
--- a/app/complete-profile/page.tsx
+++ b/app/complete-profile/page.tsx
@@ -1,0 +1,67 @@
+import { redirect } from 'next/navigation';
+
+import { getServerSupabase } from '@core/api/supabase.server';
+import { sanitizeNextPath } from '@modules/auth/lib/redirect';
+import {
+  type EventProfileIntent,
+  hasCompleteEventProfile,
+  resolveStoredBirthDate,
+} from '@modules/users/lib/eventProfileRequirements';
+import EventProfileCompletionGateway from '@modules/users/ui/EventProfileCompletionGateway';
+import { resolveStoredPhone } from '@shared/lib/phone';
+
+type PageSearchParams = {
+  next?: string;
+  intent?: string;
+};
+
+function resolveIntent(value: string | undefined): EventProfileIntent {
+  return value === 'create_event' ? 'create_event' : 'join_event';
+}
+
+function resolveCancelPath(intent: EventProfileIntent, nextPath: string) {
+  if (intent === 'create_event') return '/events';
+
+  const eventMatch = /^\/(?:payments|versus)\/([^/?#]+)/.exec(nextPath);
+  return eventMatch ? `/events/${eventMatch[1]}` : '/events';
+}
+
+export const dynamic = 'force-dynamic';
+
+export default async function CompleteProfilePage({
+  searchParams,
+}: {
+  searchParams?: PageSearchParams | Promise<PageSearchParams>;
+}) {
+  const resolvedSearchParams = searchParams ? await searchParams : undefined;
+  const intent = resolveIntent(resolvedSearchParams?.intent);
+  const nextPath =
+    sanitizeNextPath(resolvedSearchParams?.next) ||
+    (intent === 'create_event' ? '/create-event' : '/events');
+  const supabase = await getServerSupabase();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    const returnPath = `/complete-profile?${new URLSearchParams({
+      next: nextPath,
+      intent,
+    }).toString()}`;
+    redirect(`/login?next=${encodeURIComponent(returnPath)}`);
+  }
+
+  if (hasCompleteEventProfile(user)) {
+    redirect(nextPath);
+  }
+
+  return (
+    <EventProfileCompletionGateway
+      intent={intent}
+      nextPath={nextPath}
+      cancelPath={resolveCancelPath(intent, nextPath)}
+      initialPhone={resolveStoredPhone(user)}
+      initialBirthDate={resolveStoredBirthDate(user)}
+    />
+  );
+}

--- a/src/modules/admin/api/events/_actions.ts
+++ b/src/modules/admin/api/events/_actions.ts
@@ -17,6 +17,10 @@ import {
 import { normalizePaymentMethodIds } from '@shared/lib/paymentMethodSelection';
 import { ensureGoogleWalletEventClass } from '@modules/tickets/api/services/google-wallet.service';
 import { sanitizeRichTextHtml } from '@shared/lib/richText';
+import {
+  hasCompleteEventProfile,
+  REQUIRED_EVENT_PROFILE_MESSAGE,
+} from '@modules/users/lib/eventProfileRequirements';
 
 type SupabaseClientLike =
   | Awaited<ReturnType<typeof getServerSupabase>>
@@ -302,6 +306,9 @@ async function clearEventRelations(supabase: SupabaseClientLike, eventId: string
 
 export async function createEvent(input: EventUpsertInput) {
   const { adminSupabase, user } = await getAuthenticatedAdminContext('crear');
+  if (!hasCompleteEventProfile(user)) {
+    throw new Error(REQUIRED_EVENT_PROFILE_MESSAGE);
+  }
   const paymentMethodSelection = await resolveOwnedPaymentMethodSelection(
     adminSupabase,
     user.id,

--- a/src/modules/admin/ui/events/screens/NewEventScreen.tsx
+++ b/src/modules/admin/ui/events/screens/NewEventScreen.tsx
@@ -14,6 +14,10 @@ import {
 } from '@shared/lib/eventDescription';
 import { redirect } from 'next/navigation';
 import { getOrganizerOptionsForEventForm } from '@modules/admin/api/organizers/organizers.service';
+import {
+  buildEventProfileCompletionPath,
+  hasCompleteEventProfile,
+} from '@modules/users/lib/eventProfileRequirements';
 
 type Props = {
   templateId?: string;
@@ -26,6 +30,18 @@ export default async function NewEventScreen({ templateId }: Props) {
   } = await supabase.auth.getUser();
   if (!user?.id) {
     redirect('/');
+  }
+
+  if (!hasCompleteEventProfile(user)) {
+    const nextPath = templateId
+      ? `/admin/events/new?templateId=${encodeURIComponent(templateId)}`
+      : '/admin/events/new';
+    redirect(
+      buildEventProfileCompletionPath({
+        nextPath,
+        intent: 'create_event',
+      })
+    );
   }
 
   const canManageFeatured = isSuperAdmin(user as any);

--- a/src/modules/auth/ui/signup/SignupClient.tsx
+++ b/src/modules/auth/ui/signup/SignupClient.tsx
@@ -12,13 +12,23 @@ import { useAuth } from '@core/auth/AuthProvider';
 
 import { ParagraphM } from '@core/ui/Typography';
 import Input from '@core/ui/Input';
+import InternationalPhoneField from '@core/ui/InternationalPhoneField';
 import SelectComponent, { OptionSelect } from '@core/ui/SelectComponent';
 
 import type { Step, SignupStep1Values } from './signup.types';
 import { fetchCurrentOnboardingState } from '@modules/auth/lib/onboarding.client';
 import { authCallbackUrl, sanitizeNextPath } from '@modules/auth/lib/redirect';
 import { fetchLevelsOptions, fetchPositionsOptions } from '@modules/users/api/lookups.client';
-import { normalizePhoneMetadata } from '@shared/lib/phone';
+import {
+  normalizePhoneMetadata,
+  resolveStoredPhone,
+  validateInternationalPhone,
+} from '@shared/lib/phone';
+import {
+  getTodayDateInputValue,
+  resolveStoredBirthDate,
+  validateBirthDate,
+} from '@modules/users/lib/eventProfileRequirements';
 import {
   checkUsernameAvailabilityAction,
   completeOnboardingProfileAction,
@@ -106,6 +116,11 @@ export default function SignupClient() {
   const [levels, setLevels] = useState<OptionSelect[]>([]);
   const [selectedPositions, setSelectedPositions] = useState<(string | number)[]>([]);
   const [selectedLevel, setSelectedLevel] = useState<string | number | null>(null);
+  const [phone, setPhone] = useState('');
+  const [phoneError, setPhoneError] = useState('');
+  const [birthDate, setBirthDate] = useState('');
+  const [birthDateError, setBirthDateError] = useState('');
+  const maxBirthDate = useMemo(() => getTodayDateInputValue(), []);
 
   const [userId, setUserId] = useState<string | null>(null);
 
@@ -249,6 +264,8 @@ export default function SignupClient() {
         setRequiresEmailVerification(!user.email_confirmed_at);
         setValue('username', initialUsername);
         setIsIdentityConfirmed(isGenderIdentityConfirmed(metadata.gender_identity_confirmed));
+        setPhone(resolveStoredPhone(user));
+        setBirthDate(resolveStoredBirthDate(user));
 
         if (nextStep === null) {
           window.location.href = requestedNextPath || destination;
@@ -404,6 +421,20 @@ export default function SignupClient() {
     if (!selectedLevel) return toast.error('Selecciona un nivel.');
     if (selectedPositions.length === 0) return toast.error('Selecciona al menos una posicion.');
 
+    const phoneValidation = validateInternationalPhone(phone);
+    if (!phoneValidation.isValid) {
+      setPhoneError('Ingresa un celular válido.');
+      toast.error('Ingresa un celular válido.');
+      return;
+    }
+
+    const birthDateValidation = validateBirthDate(birthDate, maxBirthDate);
+    if (birthDateValidation.ok === false) {
+      setBirthDateError(birthDateValidation.message);
+      toast.error(birthDateValidation.message);
+      return;
+    }
+
     setLoading(true);
     try {
       const usernameValidation = validateUsername(username);
@@ -469,6 +500,8 @@ export default function SignupClient() {
         username: normalizedUsername,
         level_id: Number(selectedLevel),
         player_position: positionIds,
+        phone: phoneValidation.e164,
+        birth_date: birthDateValidation.value,
       };
 
       // We create the final profile here. If a draft exists and backend treats it as duplicate,
@@ -518,6 +551,8 @@ export default function SignupClient() {
         const { error: metadataError } = await supabase.auth.updateUser({
           data: {
             ...normalizePhoneMetadata(authenticatedUser.user_metadata),
+            phone: phoneValidation.e164,
+            birth_date: birthDateValidation.value,
             gender_identity_confirmed: true,
           },
         });
@@ -852,6 +887,43 @@ export default function SignupClient() {
             />
             <p className="text-xs text-slate-500 -mt-2">Máximo 15 caracteres, sin espacios.</p>
 
+            <InternationalPhoneField
+              label="Número de celular"
+              name="phone"
+              value={phone}
+              onChange={(nextPhone) => {
+                setPhone(nextPhone);
+                if (phoneError) setPhoneError('');
+              }}
+              onBlur={() => {
+                const validation = validateInternationalPhone(phone);
+                setPhoneError(validation.isValid ? '' : 'Ingresa un celular válido.');
+              }}
+              placeholder="999 999 999"
+              errorText={phoneError}
+              required
+            />
+
+            <Input
+              label="Fecha de nacimiento"
+              type="date"
+              name="birth_date"
+              value={birthDate}
+              min="1900-01-01"
+              max={maxBirthDate}
+              autoComplete="bday"
+              required
+              onChange={(event) => {
+                setBirthDate(event.currentTarget.value);
+                if (birthDateError) setBirthDateError('');
+              }}
+              onBlur={() => {
+                const validation = validateBirthDate(birthDate, maxBirthDate);
+                setBirthDateError(validation.ok === true ? '' : validation.message);
+              }}
+              errorText={birthDateError}
+            />
+
             <label className="w-full">
               <div className="mb-1">
                 <ParagraphM fontWeight="semibold">
@@ -916,6 +988,8 @@ export default function SignupClient() {
                 loading ||
                 !isIdentityConfirmed ||
                 !validateUsername(username).ok ||
+                !validateInternationalPhone(phone).isValid ||
+                !validateBirthDate(birthDate, maxBirthDate).ok ||
                 !selectedLevel ||
                 selectedPositions.length === 0
               }

--- a/src/modules/auth/ui/useSessionGuardNavigation.ts
+++ b/src/modules/auth/ui/useSessionGuardNavigation.ts
@@ -5,6 +5,11 @@ import { useRouter } from 'next/navigation';
 import toast from 'react-hot-toast';
 
 import { useAuth } from '@core/auth/AuthProvider';
+import {
+  buildEventProfileCompletionPath,
+  type EventProfileIntent,
+  hasCompleteEventProfile,
+} from '@modules/users/lib/eventProfileRequirements';
 
 type SessionNavigationRequest = {
   destination: string;
@@ -15,6 +20,8 @@ type SessionNavigationRequest = {
   loginRedirectMessage?: string;
   requireEmailConfirmed?: boolean;
   emailConfirmationMessage?: string;
+  requireEventProfile?: boolean;
+  eventProfileIntent?: EventProfileIntent;
 };
 
 const DEFAULT_EMAIL_CONFIRMATION_MESSAGE = 'Verifica tu identidad para poder inscribirte a este evento.';
@@ -45,10 +52,20 @@ export function useSessionGuardNavigation() {
   const [pendingRequest, setPendingRequest] = useState<SessionNavigationRequest | null>(null);
   const [overlayMessage, setOverlayMessage] = useState<string | null>(null);
 
-  function canNavigateAuthenticated(request: SessionNavigationRequest) {
-    if (!request.requireEmailConfirmed || user?.email_confirmed_at) return true;
-    toast.error(request.emailConfirmationMessage || DEFAULT_EMAIL_CONFIRMATION_MESSAGE);
-    return false;
+  function resolveAuthenticatedDestination(request: SessionNavigationRequest) {
+    if (request.requireEmailConfirmed && !user?.email_confirmed_at) {
+      toast.error(request.emailConfirmationMessage || DEFAULT_EMAIL_CONFIRMATION_MESSAGE);
+      return null;
+    }
+
+    if (request.requireEventProfile && !hasCompleteEventProfile(user)) {
+      return buildEventProfileCompletionPath({
+        nextPath: request.destination,
+        intent: request.eventProfileIntent || 'join_event',
+      });
+    }
+
+    return request.destination;
   }
 
   function navigateWithSessionCheck(request: SessionNavigationRequest) {
@@ -61,9 +78,10 @@ export function useSessionGuardNavigation() {
     }
 
     if (user) {
-      if (!canNavigateAuthenticated(request)) return;
+      const destination = resolveAuthenticatedDestination(request);
+      if (!destination) return;
       setOverlayMessage(request.authenticatedMessage);
-      pushOnNextFrame(router, request.destination);
+      pushOnNextFrame(router, destination);
       return;
     }
 
@@ -81,12 +99,13 @@ export function useSessionGuardNavigation() {
     setPendingRequest(null);
 
     if (user) {
-      if (!canNavigateAuthenticated(request)) {
+      const destination = resolveAuthenticatedDestination(request);
+      if (!destination) {
         setOverlayMessage(null);
         return;
       }
       setOverlayMessage(request.authenticatedMessage);
-      pushOnNextFrame(router, request.destination);
+      pushOnNextFrame(router, destination);
       return;
     }
 

--- a/src/modules/events/api/handlers/events.ts
+++ b/src/modules/events/api/handlers/events.ts
@@ -11,6 +11,10 @@ import { getEventCatalogs } from '@modules/events/api/queries/getEventCatalogs';
 import { getEventsExplorer } from '@modules/events/api/queries/getEventsExplorer';
 import { CreateEventPayload, EventEntity } from '@modules/events/model/types';
 import { getIsoDateInTimeZone, normalizeDateTimeLocalToLima } from '@shared/lib/dateTime';
+import {
+  hasCompleteEventProfile,
+  REQUIRED_EVENT_PROFILE_MESSAGE,
+} from '@modules/users/lib/eventProfileRequirements';
 
 const EVENTS_TIMEOUT_MS = 4500;
 
@@ -238,6 +242,13 @@ export async function POST(request: Request) {
 
     if (!isAdmin(user)) {
       return NextResponse.json({ error: 'Solo admins pueden crear eventos por esta ruta.' }, { status: 403 });
+    }
+
+    if (!hasCompleteEventProfile(user)) {
+      return NextResponse.json(
+        { error: REQUIRED_EVENT_PROFILE_MESSAGE, code: 'PROFILE_DETAILS_REQUIRED' },
+        { status: 422 }
+      );
     }
 
     const limitedByUser = await rateLimitByIdentifier({

--- a/src/modules/events/lib/createEventEntry.server.ts
+++ b/src/modules/events/lib/createEventEntry.server.ts
@@ -2,6 +2,10 @@ import { getServerSupabase } from '@core/api/supabase.server';
 import { resolveNextOnboardingStep } from '@modules/auth/lib/onboarding-state';
 import { isAdmin } from '@shared/lib/auth/isAdmin';
 import { resolveStoredPhone } from '@shared/lib/phone';
+import {
+  buildEventProfileCompletionPath,
+  hasCompleteEventProfile,
+} from '@modules/users/lib/eventProfileRequirements';
 
 type OnboardingProfileRow = {
   username?: string | null;
@@ -116,6 +120,16 @@ export async function resolveCreateEventEntryState(): Promise<CreateEventEntrySt
     return {
       kind: 'redirect',
       destination: onboardingRedirect,
+    };
+  }
+
+  if (!hasCompleteEventProfile(user)) {
+    return {
+      kind: 'redirect',
+      destination: buildEventProfileCompletionPath({
+        nextPath: CREATE_EVENT_ENTRY_PATH,
+        intent: 'create_event',
+      }),
     };
   }
 

--- a/src/modules/events/ui/cardEvents/CardEventItem.tsx
+++ b/src/modules/events/ui/cardEvents/CardEventItem.tsx
@@ -92,6 +92,8 @@ const CardEventItem = ({ cardEvents, variant = 'legacy' }: CardEventItemProps) =
       loginRedirectMessage: 'Redirigiendo al login...',
       requireEmailConfirmed: true,
       emailConfirmationMessage: 'Verifica tu identidad para poder inscribirte a este evento.',
+      requireEventProfile: true,
+      eventProfileIntent: 'join_event',
     });
   }
 

--- a/src/modules/events/ui/eventDetails/EventDetailsClient.tsx
+++ b/src/modules/events/ui/eventDetails/EventDetailsClient.tsx
@@ -361,6 +361,8 @@ export default function EventDetailsClient({ data }: Props) {
       loginRedirectMessage: 'Redirigiendo al login...',
       requireEmailConfirmed: true,
       emailConfirmationMessage: 'Verifica tu identidad para poder inscribirte a este evento.',
+      requireEventProfile: true,
+      eventProfileIntent: 'join_event',
     });
   };
 

--- a/src/modules/events/ui/explorer/EventListPanel.tsx
+++ b/src/modules/events/ui/explorer/EventListPanel.tsx
@@ -140,6 +140,8 @@ export default function EventListPanel({
       loginRedirectMessage: 'Redirigiendo al login...',
       requireEmailConfirmed: true,
       emailConfirmationMessage: 'Verifica tu identidad para poder inscribirte a este evento.',
+      requireEventProfile: true,
+      eventProfileIntent: 'join_event',
     });
   }
 

--- a/src/modules/payments/api/handlers/payments.confirm.ts
+++ b/src/modules/payments/api/handlers/payments.confirm.ts
@@ -22,6 +22,10 @@ import {
   shouldBlockCouponReuse,
   type CouponReimbursementStatus,
 } from '@modules/payments/lib/couponReimbursement';
+import {
+  hasCompleteEventProfile,
+  REQUIRED_EVENT_PROFILE_MESSAGE,
+} from '@modules/users/lib/eventProfileRequirements';
 
 function parseEventId(value: unknown) {
   const n = Number(value);
@@ -377,6 +381,13 @@ export async function POST(request: Request) {
 
     if (userError || !user) {
       return NextResponse.json({ error: 'Debes iniciar sesión.' }, { status: 401 });
+    }
+
+    if (!hasCompleteEventProfile(user)) {
+      return NextResponse.json(
+        { error: REQUIRED_EVENT_PROFILE_MESSAGE, code: 'PROFILE_DETAILS_REQUIRED' },
+        { status: 422 }
+      );
     }
 
     const body = await request.json().catch(() => ({}));

--- a/src/modules/payments/api/queries/getPaymentPageData.ts
+++ b/src/modules/payments/api/queries/getPaymentPageData.ts
@@ -3,6 +3,7 @@ import { getApprovedParticipantsCountByEventId } from '@modules/events/api/queri
 import { getViewerRegistrationState } from '@modules/events/api/queries/getViewerApprovedRegistrations';
 import { getPlacesLeft, isEventSoldOut } from '@modules/events/lib/eventCapacity';
 import { getActiveLinkedPaymentMethodIdsForEvent } from '@shared/lib/paymentMethodSelection.server';
+import { hasCompleteEventProfile } from '@modules/users/lib/eventProfileRequirements';
 
 export type PaymentPageData = {
   event: any;
@@ -13,6 +14,8 @@ export type PaymentPageData = {
 export const PAYMENT_METHOD_NOT_CONFIGURED = 'PAYMENT_METHOD_NOT_CONFIGURED';
 export const EVENT_NOT_AVAILABLE = 'EVENT_NOT_AVAILABLE';
 export const EVENT_REGISTRATION_LOCKED = 'EVENT_REGISTRATION_LOCKED';
+export const EVENT_REGISTRATION_AUTH_REQUIRED = 'EVENT_REGISTRATION_AUTH_REQUIRED';
+export const EVENT_PROFILE_DETAILS_REQUIRED = 'EVENT_PROFILE_DETAILS_REQUIRED';
 
 export async function getPaymentPageData(id: string) {
   const supabase = await getServerSupabase();
@@ -35,7 +38,15 @@ export async function getPaymentPageData(id: string) {
     data: { user },
   } = await supabase.auth.getUser();
 
-  const viewerRegistrationState = user?.id ? await getViewerRegistrationState(event.id, supabase, user.id) : null;
+  if (!user) {
+    throw new Error(EVENT_REGISTRATION_AUTH_REQUIRED);
+  }
+
+  if (!hasCompleteEventProfile(user)) {
+    throw new Error(EVENT_PROFILE_DETAILS_REQUIRED);
+  }
+
+  const viewerRegistrationState = await getViewerRegistrationState(event.id, supabase, user.id);
   const viewerHasApprovedRegistration = viewerRegistrationState === 'approved';
   const viewerHasPendingRegistration = viewerRegistrationState === 'pending';
 

--- a/src/modules/payments/ui/screens/PaymentPage.tsx
+++ b/src/modules/payments/ui/screens/PaymentPage.tsx
@@ -2,6 +2,8 @@
 import PaymentStepper from '../PaymentStepper/PaymentStepperComponent';
 import {
   EVENT_NOT_AVAILABLE,
+  EVENT_PROFILE_DETAILS_REQUIRED,
+  EVENT_REGISTRATION_AUTH_REQUIRED,
   EVENT_REGISTRATION_LOCKED,
   getPaymentPageData,
   PAYMENT_METHOD_NOT_CONFIGURED,
@@ -10,6 +12,7 @@ import { hasEventEnded } from '@modules/events/lib/eventTiming';
 import { isVersusEventTypeName } from '@modules/events/lib/eventTypeRules';
 import { notFound, redirect } from 'next/navigation';
 import Link from 'next/link';
+import { buildEventProfileCompletionPath } from '@modules/users/lib/eventProfileRequirements';
 
 export default async function PaymentPage({ id }: { id: string }) {
   let data: Awaited<ReturnType<typeof getPaymentPageData>> | null = null;
@@ -22,6 +25,19 @@ export default async function PaymentPage({ id }: { id: string }) {
   }
 
   if (!data) {
+    if (loadError instanceof Error && loadError.message === EVENT_REGISTRATION_AUTH_REQUIRED) {
+      redirect(`/login?next=${encodeURIComponent(`/payments/${id}`)}`);
+    }
+
+    if (loadError instanceof Error && loadError.message === EVENT_PROFILE_DETAILS_REQUIRED) {
+      redirect(
+        buildEventProfileCompletionPath({
+          nextPath: `/payments/${id}`,
+          intent: 'join_event',
+        })
+      );
+    }
+
     if (loadError instanceof Error && loadError.message === EVENT_REGISTRATION_LOCKED) {
       redirect(`/events/${id}`);
     }

--- a/src/modules/users/actions/createProfile.actions.ts
+++ b/src/modules/users/actions/createProfile.actions.ts
@@ -4,7 +4,8 @@ import { createProfile, updateProfileByUserId } from '@modules/users/api/profile
 import { getServerSupabase } from '@core/api/supabase.server';
 import { getAdminSupabase } from '@core/api/supabase.admin';
 import { log } from '@core/lib/logger';
-import { normalizePhoneMetadata } from '@shared/lib/phone';
+import { normalizePhoneMetadata, validateInternationalPhone } from '@shared/lib/phone';
+import { validateBirthDate } from '@modules/users/lib/eventProfileRequirements';
 import {
   USERNAME_REQUIREMENTS_MESSAGE,
   validateUsername,
@@ -21,6 +22,11 @@ export type UpdateProfilePayload = {
   username: string;
   level_id: number;
   player_position: number[];
+};
+
+export type CompleteOnboardingProfilePayload = CreateProfilePayload & {
+  phone: string;
+  birth_date: string;
 };
 
 export type CompleteOnboardingProfileResult =
@@ -365,13 +371,16 @@ async function saveOnboardingProfileState(
   }
 }
 
-async function syncAuthUserMetadata(userId: string, username: string) {
+async function syncAuthUserMetadata(
+  userId: string,
+  details: { username: string; phone: string; birthDate: string }
+) {
   const adminSupabase = tryGetAdminSupabase('syncAuthUserMetadata');
   if (!adminSupabase) {
     return;
   }
 
-  const normalizedUsername = username.trim();
+  const normalizedUsername = details.username.trim();
 
   const { data: authUserData, error: getUserError } = await adminSupabase.auth.admin.getUserById(
     userId
@@ -390,6 +399,8 @@ async function syncAuthUserMetadata(userId: string, username: string) {
   const nextMetadata: Record<string, unknown> = {
     ...currentMetadata,
     username: normalizedUsername,
+    phone: details.phone,
+    birth_date: details.birthDate,
     gender_identity_confirmed: true,
   };
 
@@ -411,7 +422,7 @@ async function syncAuthUserMetadata(userId: string, username: string) {
 }
 
 export async function completeOnboardingProfileAction(
-  payload: CreateProfilePayload
+  payload: CompleteOnboardingProfilePayload
 ): Promise<CompleteOnboardingProfileResult> {
   try {
     const usernameValidation = validateUsername(payload.username);
@@ -423,7 +434,31 @@ export async function completeOnboardingProfileAction(
       };
     }
 
+    const phoneValidation = validateInternationalPhone(payload.phone);
+    if (!phoneValidation.isValid) {
+      return {
+        ok: false,
+        code: 'UNKNOWN',
+        message: 'Ingresa un celular válido.',
+      };
+    }
+
+    const birthDateValidation = validateBirthDate(payload.birth_date);
+    if (birthDateValidation.ok === false) {
+      return {
+        ok: false,
+        code: 'UNKNOWN',
+        message: birthDateValidation.message,
+      };
+    }
+
     const normalizedUsername = usernameValidation.value;
+    const createProfilePayload: CreateProfilePayload = {
+      user: payload.user,
+      username: normalizedUsername,
+      level_id: payload.level_id,
+      player_position: payload.player_position,
+    };
     const profilePayload: UpdateProfilePayload = {
       username: normalizedUsername,
       level_id: payload.level_id as number,
@@ -446,10 +481,7 @@ export async function completeOnboardingProfileAction(
       });
 
       try {
-        await createProfile({
-          ...payload,
-          username: normalizedUsername,
-        });
+        await createProfile(createProfilePayload);
       } catch (createError: any) {
         const createMessage = normalizeErrorMessage(createError);
         if (isProfileUsernameConflictError(createMessage)) {
@@ -479,13 +511,7 @@ export async function completeOnboardingProfileAction(
           }
         );
 
-        await saveProfileAndPositionsWithRetry(
-          {
-            ...payload,
-            username: normalizedUsername,
-          },
-          4
-        );
+        await saveProfileAndPositionsWithRetry(createProfilePayload, 4);
         usedDirectSupabaseFallback = true;
       }
     }
@@ -499,7 +525,11 @@ export async function completeOnboardingProfileAction(
       });
     }
 
-    await syncAuthUserMetadata(payload.user, normalizedUsername);
+    await syncAuthUserMetadata(payload.user, {
+      username: normalizedUsername,
+      phone: phoneValidation.e164,
+      birthDate: birthDateValidation.value,
+    });
     return { ok: true };
   } catch (error: any) {
     const message = normalizeErrorMessage(error);

--- a/src/modules/users/lib/eventProfileRequirements.ts
+++ b/src/modules/users/lib/eventProfileRequirements.ts
@@ -1,0 +1,98 @@
+import { resolveStoredPhone, validateInternationalPhone } from '@shared/lib/phone';
+
+export const REQUIRED_EVENT_PROFILE_MESSAGE =
+  'Completa tu celular y fecha de nacimiento para continuar.';
+
+export type EventProfileIntent = 'join_event' | 'create_event';
+
+export type EventProfileMetadataSource = {
+  app_metadata?: Record<string, unknown> | null;
+  user_metadata?: Record<string, unknown> | null;
+};
+
+export type BirthDateValidationResult =
+  | { ok: true; value: string }
+  | { ok: false; message: string };
+
+function padDatePart(value: number) {
+  return String(value).padStart(2, '0');
+}
+
+export function getTodayDateInputValue(now = new Date()) {
+  return `${now.getFullYear()}-${padDatePart(now.getMonth() + 1)}-${padDatePart(now.getDate())}`;
+}
+
+export function validateBirthDate(value: unknown, today = getTodayDateInputValue()): BirthDateValidationResult {
+  const normalized = String(value || '').trim();
+  if (!normalized) {
+    return { ok: false, message: 'Ingresa tu fecha de nacimiento.' };
+  }
+
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(normalized);
+  if (!match) {
+    return { ok: false, message: 'Ingresa una fecha de nacimiento válida.' };
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  const isRealDate =
+    parsed.getUTCFullYear() === year &&
+    parsed.getUTCMonth() === month - 1 &&
+    parsed.getUTCDate() === day;
+
+  if (!isRealDate || year < 1900) {
+    return { ok: false, message: 'Ingresa una fecha de nacimiento válida.' };
+  }
+
+  if (normalized > today) {
+    return { ok: false, message: 'La fecha de nacimiento no puede estar en el futuro.' };
+  }
+
+  return { ok: true, value: normalized };
+}
+
+export function resolveStoredBirthDate(source?: EventProfileMetadataSource | null) {
+  const candidates = [
+    source?.user_metadata?.birth_date,
+    source?.user_metadata?.date_of_birth,
+    source?.user_metadata?.birthday,
+    source?.user_metadata?.fecha_nacimiento,
+    source?.app_metadata?.birth_date,
+    source?.app_metadata?.date_of_birth,
+  ];
+
+  for (const candidate of candidates) {
+    const normalized = String(candidate || '').trim();
+    if (validateBirthDate(normalized).ok) return normalized;
+  }
+
+  return '';
+}
+
+export function getMissingEventProfileFields(source?: EventProfileMetadataSource | null) {
+  const phone = resolveStoredPhone(source);
+  const birthDate = resolveStoredBirthDate(source);
+
+  return {
+    phone: !validateInternationalPhone(phone).isValid,
+    birthDate: !validateBirthDate(birthDate).ok,
+  };
+}
+
+export function hasCompleteEventProfile(source?: EventProfileMetadataSource | null) {
+  const missing = getMissingEventProfileFields(source);
+  return !missing.phone && !missing.birthDate;
+}
+
+export function buildEventProfileCompletionPath(options: {
+  nextPath: string;
+  intent: EventProfileIntent;
+}) {
+  const params = new URLSearchParams({
+    next: options.nextPath,
+    intent: options.intent,
+  });
+  return `/complete-profile?${params.toString()}`;
+}

--- a/src/modules/users/ui/EventProfileCompletionGateway.tsx
+++ b/src/modules/users/ui/EventProfileCompletionGateway.tsx
@@ -1,0 +1,239 @@
+'use client';
+
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import toast from 'react-hot-toast';
+
+import { getBrowserSupabase } from '@core/api/supabase.browser';
+import { useAuth } from '@core/auth/AuthProvider';
+import Input from '@core/ui/Input';
+import InternationalPhoneField from '@core/ui/InternationalPhoneField';
+import { normalizePhoneMetadata, validateInternationalPhone } from '@shared/lib/phone';
+import {
+  type EventProfileIntent,
+  getMissingEventProfileFields,
+  getTodayDateInputValue,
+  validateBirthDate,
+} from '@modules/users/lib/eventProfileRequirements';
+
+type Props = {
+  intent: EventProfileIntent;
+  nextPath: string;
+  cancelPath: string;
+  initialPhone?: string;
+  initialBirthDate?: string;
+};
+
+const copyByIntent: Record<
+  EventProfileIntent,
+  { eyebrow: string; title: string; description: string; submit: string }
+> = {
+  join_event: {
+    eyebrow: 'Inscripción al evento',
+    title: 'Completa tus datos para inscribirte',
+    description:
+      'Necesitamos estos datos antes de registrar tu inscripción. Al guardarlos, continuarás automáticamente.',
+    submit: 'Guardar y continuar',
+  },
+  create_event: {
+    eyebrow: 'Crear evento',
+    title: 'Completa tus datos para crear un evento',
+    description:
+      'Necesitamos estos datos antes de abrir el formulario del evento. Al guardarlos, continuarás automáticamente.',
+    submit: 'Guardar y crear evento',
+  },
+};
+
+export default function EventProfileCompletionGateway({
+  intent,
+  nextPath,
+  cancelPath,
+  initialPhone = '',
+  initialBirthDate = '',
+}: Props) {
+  const router = useRouter();
+  const { user, refreshProfile } = useAuth();
+  const [phone, setPhone] = useState(initialPhone);
+  const [birthDate, setBirthDate] = useState(initialBirthDate);
+  const [phoneError, setPhoneError] = useState('');
+  const [birthDateError, setBirthDateError] = useState('');
+  const [pending, setPending] = useState(false);
+  const copy = copyByIntent[intent];
+  const maxBirthDate = useMemo(() => getTodayDateInputValue(), []);
+  const initiallyMissing = useMemo(
+    () =>
+      getMissingEventProfileFields({
+        user_metadata: {
+          phone: initialPhone,
+          birth_date: initialBirthDate,
+        },
+      }),
+    [initialBirthDate, initialPhone]
+  );
+  const requirementExplanation = initiallyMissing.phone
+    ? initiallyMissing.birthDate
+      ? 'Tu celular se usa para coordinación del evento y tu fecha de nacimiento para mantener tus datos de participación completos.'
+      : 'Tu celular se usa para la coordinación relacionada con tus eventos.'
+    : 'Tu fecha de nacimiento mantiene completos tus datos de participación.';
+
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !pending) {
+        router.replace(cancelPath);
+      }
+    };
+    window.addEventListener('keydown', handleEscape);
+
+    return () => {
+      document.body.style.overflow = '';
+      window.removeEventListener('keydown', handleEscape);
+    };
+  }, [cancelPath, pending, router]);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const phoneValidation = validateInternationalPhone(phone);
+    const birthDateValidation = validateBirthDate(birthDate, maxBirthDate);
+    const nextPhoneError = phoneValidation.isValid ? '' : 'Ingresa un celular válido.';
+    const nextBirthDateError =
+      birthDateValidation.ok === true ? '' : birthDateValidation.message;
+    setPhoneError(nextPhoneError);
+    setBirthDateError(nextBirthDateError);
+
+    if (nextPhoneError || nextBirthDateError || birthDateValidation.ok === false) return;
+
+    setPending(true);
+    try {
+      const supabase = getBrowserSupabase();
+      const currentMetadata = normalizePhoneMetadata(user?.user_metadata);
+      const { error } = await supabase.auth.updateUser({
+        data: {
+          ...currentMetadata,
+          phone: phoneValidation.e164,
+          birth_date: birthDateValidation.value,
+        },
+      });
+
+      if (error) throw error;
+
+      await refreshProfile().catch(() => undefined);
+      toast.success('Datos guardados. Ya puedes continuar.');
+      router.replace(nextPath);
+      router.refresh();
+    } catch (error: any) {
+      toast.error(error?.message || 'No pudimos guardar tus datos. Intenta nuevamente.');
+    } finally {
+      setPending(false);
+    }
+  }
+
+  function handleCancel() {
+    if (pending) return;
+    router.replace(cancelPath);
+  }
+
+  return (
+    <main className="min-h-[70vh] bg-slate-50/70" aria-label="Completar datos personales">
+      <div className="fixed inset-0 z-[110] flex items-center justify-center overflow-y-auto bg-slate-900/70 px-4 py-8 backdrop-blur-[2px]">
+        <section
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="event-profile-completion-title"
+          className="relative w-full max-w-lg rounded-[28px] border border-slate-200 bg-white p-6 shadow-[0_30px_80px_-30px_rgba(15,23,42,0.6)] sm:p-7"
+        >
+          <button
+            type="button"
+            aria-label="Cerrar"
+            disabled={pending}
+            onClick={handleCancel}
+            className="absolute right-4 top-4 inline-flex h-9 w-9 items-center justify-center rounded-full bg-slate-100 text-slate-500 transition hover:bg-slate-200 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+
+          <div className="pr-10">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-mulberry">
+              {copy.eyebrow}
+            </p>
+            <h1
+              id="event-profile-completion-title"
+              className="mt-2 text-2xl font-eastman-extrabold leading-tight text-slate-900"
+            >
+              {copy.title}
+            </h1>
+            <p className="mt-2 text-sm leading-6 text-slate-600">{copy.description}</p>
+          </div>
+
+          <form className="mt-6 grid gap-4" onSubmit={handleSubmit} noValidate>
+            {initiallyMissing.phone ? (
+              <InternationalPhoneField
+                label="Número de celular"
+                name="phone"
+                placeholder="999 999 999"
+                value={phone}
+                onChange={(nextPhone) => {
+                  setPhone(nextPhone);
+                  if (phoneError) setPhoneError('');
+                }}
+                onBlur={() => {
+                  const validation = validateInternationalPhone(phone);
+                  setPhoneError(validation.isValid ? '' : 'Ingresa un celular válido.');
+                }}
+                errorText={phoneError}
+                size="lg"
+                required
+              />
+            ) : null}
+
+            {initiallyMissing.birthDate ? (
+              <Input
+                label="Fecha de nacimiento"
+                name="birth_date"
+                type="date"
+                value={birthDate}
+                min="1900-01-01"
+                max={maxBirthDate}
+                required
+                autoComplete="bday"
+                onChange={(event) => {
+                  setBirthDate(event.currentTarget.value);
+                  if (birthDateError) setBirthDateError('');
+                }}
+                onBlur={() => {
+                  const validation = validateBirthDate(birthDate, maxBirthDate);
+                  setBirthDateError(validation.ok === true ? '' : validation.message);
+                }}
+                errorText={birthDateError}
+              />
+            ) : null}
+
+            <p className="rounded-2xl bg-slate-50 px-4 py-3 text-xs leading-5 text-slate-600">
+              {requirementExplanation}
+            </p>
+
+            <button
+              type="submit"
+              disabled={pending}
+              className="inline-flex h-12 items-center justify-center rounded-full bg-mulberry px-6 text-sm font-semibold text-white transition hover:bg-[#470760] disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {pending ? 'Guardando...' : copy.submit}
+            </button>
+
+            <button
+              type="button"
+              disabled={pending}
+              onClick={handleCancel}
+              className="text-sm font-semibold text-slate-600 transition hover:text-slate-900 disabled:opacity-50"
+            >
+              Ahora no
+            </button>
+          </form>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/modules/users/ui/ProfileUpdateForm.tsx
+++ b/src/modules/users/ui/ProfileUpdateForm.tsx
@@ -16,6 +16,11 @@ import {
   validateInternationalPhone,
 } from '@shared/lib/phone';
 import {
+  getTodayDateInputValue,
+  resolveStoredBirthDate,
+  validateBirthDate,
+} from '@modules/users/lib/eventProfileRequirements';
+import {
   USERNAME_MAX_LENGTH,
   validateUsername,
   validateUsernameForForm,
@@ -57,7 +62,11 @@ export default function ProfileUpdateForm({
   const [isLoading, setIsLoading] = useState(false);
   const [phone, setPhone] = useState('');
   const [phoneError, setPhoneError] = useState('');
+  const [birthDate, setBirthDate] = useState('');
+  const [birthDateError, setBirthDateError] = useState('');
   const initialPhone = resolveStoredPhone(user);
+  const initialBirthDate = resolveStoredBirthDate(user);
+  const maxBirthDate = getTodayDateInputValue();
 
   const {
     register,
@@ -93,7 +102,9 @@ export default function ProfileUpdateForm({
   useEffect(() => {
     setPhone(initialPhone);
     setPhoneError('');
-  }, [initialPhone]);
+    setBirthDate(initialBirthDate);
+    setBirthDateError('');
+  }, [initialBirthDate, initialPhone]);
 
   const levelValue = watch('level_id');
   const positionsValue = watch('positions');
@@ -126,9 +137,15 @@ export default function ProfileUpdateForm({
     }
     const normalizedUsername = usernameValidation.value;
 
-    const normalizedPhone = phone.trim() ? normalizeInternationalPhone(phone) : '';
-    if (phone.trim() && !normalizedPhone) {
+    const normalizedPhone = normalizeInternationalPhone(phone);
+    if (!normalizedPhone) {
       setPhoneError('Ingresa un celular válido.');
+      return;
+    }
+
+    const birthDateValidation = validateBirthDate(birthDate, maxBirthDate);
+    if (birthDateValidation.ok === false) {
+      setBirthDateError(birthDateValidation.message);
       return;
     }
 
@@ -136,6 +153,7 @@ export default function ProfileUpdateForm({
     try {
       clearErrors();
       setPhoneError('');
+      setBirthDateError('');
       const updateData: UserProfileUpdate = {
         username: normalizedUsername,
         level_id: data.level_id as number,
@@ -148,7 +166,8 @@ export default function ProfileUpdateForm({
       const nextMetadata: Record<string, unknown> = {
         ...currentMetadata,
         username: normalizedUsername,
-        phone: normalizedPhone || null,
+        phone: normalizedPhone,
+        birth_date: birthDateValidation.value,
       };
 
       const { error: metadataError } = await supabase.auth.updateUser({
@@ -156,7 +175,7 @@ export default function ProfileUpdateForm({
       });
 
       if (metadataError) {
-        console.warn('Could not sync profile username into auth metadata', metadataError.message);
+        throw new Error('No pudimos guardar el celular y la fecha de nacimiento. Intenta nuevamente.');
       }
 
       const nextProfileData: UserProfileData = {
@@ -182,6 +201,7 @@ export default function ProfileUpdateForm({
         positions: [...data.positions],
       });
       setPhone(normalizedPhone || '');
+      setBirthDate(birthDateValidation.value);
       await refreshProfile().catch(() => undefined);
       toast.success('¡Se actualizó tu perfil con éxito!');
     } catch (error: any) {
@@ -248,6 +268,7 @@ export default function ProfileUpdateForm({
         <div className="flex h-full flex-col">
           <InternationalPhoneField
             label="Celular"
+            required
             value={phone}
             onChange={(nextPhone) => {
               setPhone(nextPhone);
@@ -255,7 +276,7 @@ export default function ProfileUpdateForm({
             }}
             onBlur={() => {
               if (!phone.trim()) {
-                setPhoneError('');
+                setPhoneError('Ingresa un celular válido.');
                 return;
               }
 
@@ -267,6 +288,32 @@ export default function ProfileUpdateForm({
           />
           <p className={helperTextClassName}>
             Lo usaremos para prellenar tus flujos y mantener tu contacto actualizado.
+          </p>
+        </div>
+
+        <div className="flex h-full flex-col">
+          <Input
+            label="Fecha de nacimiento"
+            type="date"
+            name="birth_date"
+            value={birthDate}
+            min="1900-01-01"
+            max={maxBirthDate}
+            autoComplete="bday"
+            required
+            onChange={(event) => {
+              setBirthDate(event.currentTarget.value);
+              if (birthDateError) setBirthDateError('');
+            }}
+            onBlur={() => {
+              const validation = validateBirthDate(birthDate, maxBirthDate);
+              setBirthDateError(validation.ok === true ? '' : validation.message);
+            }}
+            errorText={birthDateError}
+            bgColor="bg-white"
+          />
+          <p className={helperTextClassName}>
+            La usamos para mantener completos tus datos de participación.
           </p>
         </div>
 


### PR DESCRIPTION
## Resumen
- agrega celular y fecha de nacimiento obligatorios al registro
- solicita únicamente los datos faltantes antes de inscribirse o crear un evento
- continúa automáticamente con la acción original después de guardar
- protege también las rutas y endpoints directos de creación e inscripción
- permite editar ambos datos desde Mi perfil

## Validaciones
- celular normalizado en formato internacional
- fecha de nacimiento válida y no futura
- sin migración de base de datos: se persiste en Supabase Auth metadata

## Pruebas
- npm run typecheck
- npm run build
- revisión responsive en 390x844 y 1280x800