### PR TITLE
feat: add team invitations and group registration

### DIFF
--- a/app/convocatorias/[token]/page.tsx
+++ b/app/convocatorias/[token]/page.tsx
@@ -1,6 +1,9 @@
 import { notFound, redirect } from 'next/navigation';
 import { getServerSupabase } from '@core/api/supabase.server';
-import { getTeamInvitationByToken } from '@modules/teams/api/services/teams.service';
+import {
+  claimTeamInvitationByToken,
+  getTeamInvitationByToken,
+} from '@modules/teams/api/services/teams.service';
 
 type Props = {
   params: Promise<{ token: string }>;
@@ -20,6 +23,12 @@ export default async function InvitationTokenRoute({ params }: Props) {
     redirect(`/login?next=${encodeURIComponent(next)}`);
   }
 
-  if (invitation.invitee_user_id !== user.id) notFound();
-  redirect(`/convocatorias?invitation=${invitation.id}`);
+  if (invitation.invitee_user_id === user.id) {
+    redirect(`/convocatorias?invitation=${invitation.id}`);
+  }
+
+  const claimedInvitation = await claimTeamInvitationByToken(token).catch(() => null);
+  if (!claimedInvitation || claimedInvitation.invitee_user_id !== user.id) notFound();
+
+  redirect(`/convocatorias?invitation=${claimedInvitation.id}`);
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -103,13 +103,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       <body
         className="h-full w-full"
         style={{
-          backgroundColor: '#fffdfb',
-          backgroundImage: `radial-gradient(42rem 30rem at 18% 2%, rgba(240, 129, 91, 0.22), transparent 60%),
-            radial-gradient(44rem 32rem at 72% 6%, rgba(179, 71, 177, 0.2), transparent 58%),
-            radial-gradient(36rem 28rem at 88% 92%, rgba(76, 129, 214, 0.16), transparent 50%),
-            linear-gradient(180deg, rgba(255, 252, 249, 1) 0%, rgba(255, 255, 255, 1) 34%)`,
-          backgroundRepeat: 'no-repeat',
-          backgroundSize: 'cover',
+          backgroundColor: '#FAF9FB',
         }}
         suppressHydrationWarning
       >

--- a/src/modules/teams/api/handlers/team-invitations.create.ts
+++ b/src/modules/teams/api/handlers/team-invitations.create.ts
@@ -6,6 +6,7 @@ import { createTeamInvitation } from '@modules/teams/api/services/teams.service'
 import { sendTeamInvitationEmail } from '@modules/teams/api/services/teamInvitationEmail.service';
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 type RouteContext = {
   params: Promise<{ teamRef: string }>;
@@ -13,6 +14,7 @@ type RouteContext = {
 
 type CreateInvitationBody = {
   candidateUserId?: unknown;
+  email?: unknown;
 };
 
 function invitationErrorStatus(error: unknown) {
@@ -27,7 +29,7 @@ function invitationErrorStatus(error: unknown) {
 async function recordInvitationEvent(input: {
   eventName: string;
   userId: string;
-  candidateUserId: string;
+  candidateUserId: string | null;
   teamId: number;
   invitationId: number;
   emailDeliveryStatus: string;
@@ -43,6 +45,7 @@ async function recordInvitationEvent(input: {
       team_id: input.teamId,
       invitation_id: input.invitationId,
       email_delivery_status: input.emailDeliveryStatus,
+      target_kind: input.candidateUserId ? 'player' : 'external_email',
     },
   });
 
@@ -74,15 +77,22 @@ export async function POST(request: Request, context: RouteContext) {
 
   const body = (await request.json().catch(() => null)) as CreateInvitationBody | null;
   const candidateUserId = String(body?.candidateUserId || '').trim();
-  if (!UUID_PATTERN.test(candidateUserId)) {
-    return jsonNoStore({ error: 'Selecciona una jugadora válida.' }, 400);
+  const inviteeEmail = String(body?.email || '').trim().toLowerCase();
+  const hasCandidate = UUID_PATTERN.test(candidateUserId);
+  const hasEmail = inviteeEmail.length <= 254 && EMAIL_PATTERN.test(inviteeEmail);
+  if (hasCandidate === hasEmail) {
+    return jsonNoStore(
+      { error: 'Selecciona una jugadora o ingresa un email válido.' },
+      400
+    );
   }
 
   try {
     const invitation = await createTeamInvitation({
       teamId,
-      deliveryMethod: 'username',
-      inviteeUserId: candidateUserId,
+      deliveryMethod: hasCandidate ? 'username' : 'email',
+      inviteeUserId: hasCandidate ? candidateUserId : null,
+      inviteeEmail: hasEmail ? inviteeEmail : null,
     });
     const delivery = await sendTeamInvitationEmail(invitation);
     const eventName = delivery.sent
@@ -92,7 +102,7 @@ export async function POST(request: Request, context: RouteContext) {
     await recordInvitationEvent({
       eventName,
       userId: user.id,
-      candidateUserId,
+      candidateUserId: invitation.invitee_user_id,
       teamId,
       invitationId: invitation.id,
       emailDeliveryStatus: delivery.sent ? 'sent' : 'failed',
@@ -104,6 +114,7 @@ export async function POST(request: Request, context: RouteContext) {
           id: invitation.id,
           teamId: invitation.team_id,
           username: invitation.invitee_username,
+          email: invitation.invitee_email,
           status: invitation.status,
           expiresAt: invitation.expires_at,
           emailDeliveryStatus: delivery.sent ? 'sent' : 'failed',
@@ -122,7 +133,7 @@ export async function POST(request: Request, context: RouteContext) {
         : status === 409
           ? 'La jugadora ya pertenece al equipo o tiene una convocatoria pendiente.'
           : status === 404
-            ? 'La jugadora ya no está disponible para recibir esta convocatoria.'
+            ? 'La destinataria ya no está disponible para recibir esta convocatoria.'
             : 'No se pudo crear la convocatoria.';
 
     if (status === 500) console.error('POST team invitation failed:', error);

--- a/src/modules/teams/api/services/teamInvitationEmail.service.ts
+++ b/src/modules/teams/api/services/teamInvitationEmail.service.ts
@@ -43,6 +43,7 @@ function buildHtml(input: {
   teamAvatarUrl: string | null;
   invitationUrl: string;
   expiration: string;
+  requiresAccount: boolean;
 }) {
   const inviteeName = escapeHtml(input.inviteeName);
   const captainName = escapeHtml(input.captainName);
@@ -65,7 +66,7 @@ function buildHtml(input: {
           ${avatar}
           <p style="margin:0 0 10px;font-size:14px;color:#6b7280;">Hola ${inviteeName},</p>
           <h1 style="margin:0 0 18px;font-size:26px;line-height:1.2;color:#280332;">${captainName} te convocó a ${teamName}</h1>
-          <p style="margin:0 auto 26px;max-width:430px;font-size:16px;line-height:1.6;color:#4b5563;">Revisa el perfil del equipo y acepta o rechaza la convocatoria desde tu cuenta de Peloteras.</p>
+          <p style="margin:0 auto 26px;max-width:430px;font-size:16px;line-height:1.6;color:#4b5563;">${input.requiresAccount ? 'Crea tu cuenta de Peloteras con este mismo correo para revisar el equipo y responder la convocatoria.' : 'Revisa el perfil del equipo y acepta o rechaza la convocatoria desde tu cuenta de Peloteras.'}</p>
           <a href="${invitationUrl}" style="display:inline-block;background:#54086f;color:#ffffff;text-decoration:none;font-weight:700;padding:14px 24px;border-radius:12px;">Ver convocatoria</a>
           <p style="margin:24px 0 0;font-size:13px;line-height:1.5;color:#6b7280;">La convocatoria vence el ${expiration}. Necesitas iniciar sesión en Peloteras para responder.</p>
         </td></tr>
@@ -82,12 +83,15 @@ function buildText(input: {
   teamName: string;
   invitationUrl: string;
   expiration: string;
+  requiresAccount: boolean;
 }) {
   return [
     `Hola ${input.inviteeName},`,
     '',
     `${input.captainName} te convocó a ${input.teamName}.`,
-    'Revisa el equipo y responde la convocatoria desde tu cuenta de Peloteras:',
+    input.requiresAccount
+      ? 'Crea tu cuenta de Peloteras con este mismo correo y responde la convocatoria:'
+      : 'Revisa el equipo y responde la convocatoria desde tu cuenta de Peloteras:',
     input.invitationUrl,
     '',
     `La convocatoria vence el ${input.expiration}.`,
@@ -177,8 +181,16 @@ export async function sendTeamInvitationEmail(
     teamAvatarUrl: team?.avatar_url ?? null,
     invitationUrl,
     expiration,
+    requiresAccount: !invitation.invitee_user_id,
   });
-  const text = buildText({ inviteeName, captainName, teamName, invitationUrl, expiration });
+  const text = buildText({
+    inviteeName,
+    captainName,
+    teamName,
+    invitationUrl,
+    expiration,
+    requiresAccount: !invitation.invitee_user_id,
+  });
   const apiKey = String(process.env.RESEND_API_KEY || '').trim();
   const from = String(process.env.EMAIL_FROM || process.env.RESEND_FROM || '').trim();
 

--- a/src/modules/teams/api/services/teams.service.ts
+++ b/src/modules/teams/api/services/teams.service.ts
@@ -702,6 +702,26 @@ export async function getTeamInvitationByToken(
   });
 }
 
+export async function claimTeamInvitationByToken(
+  token: string
+): Promise<TeamInvitationRow> {
+  const normalizedToken = token.trim();
+  if (!normalizedToken) throw new Error('Invitation token is required');
+
+  const supabase = await getSupabase();
+  const { data, error } = await supabase
+    .rpc('claim_team_invitation_by_token', {
+      p_token: normalizedToken,
+    })
+    .single();
+
+  if (error || !data) {
+    throw new Error(error?.message || 'Team invitation claim failed');
+  }
+
+  return data as TeamInvitationRow;
+}
+
 export async function respondToTeamInvitation(
   invitationId: number,
   response: 'accepted' | 'rejected'

--- a/src/modules/teams/model/types.ts
+++ b/src/modules/teams/model/types.ts
@@ -94,6 +94,16 @@ export type TeamInvitationCandidate = {
   status: TeamInvitationCandidateStatus;
 };
 
+export type TeamInvitationSelection =
+  | {
+      kind: 'player';
+      candidate: TeamInvitationCandidate;
+    }
+  | {
+      kind: 'email';
+      email: string;
+    };
+
 export type TeamMembershipSummary = {
   role: TeamMemberRole;
   status: TeamMemberStatus;

--- a/src/modules/teams/ui/PlayerSearchInput.tsx
+++ b/src/modules/teams/ui/PlayerSearchInput.tsx
@@ -2,16 +2,21 @@
 
 import { CheckIcon, ClockIcon, UserPlusIcon } from '@heroicons/react/24/outline';
 import { useEffect, useMemo, useState } from 'react';
-import type { TeamInvitationCandidate } from '@modules/teams/model/types';
+import type {
+  TeamInvitationCandidate,
+  TeamInvitationSelection,
+} from '@modules/teams/model/types';
 import { useDebounce } from '../../../shared/lib/hooks/useDebounce';
 
 interface Props {
   teamId: number;
-  onSelect: (player: TeamInvitationCandidate) => void;
-  selected: TeamInvitationCandidate[];
+  onSelect: (selection: TeamInvitationSelection) => void;
+  selected: TeamInvitationSelection | null;
   placeholder?: string;
   minChars?: number;
 }
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export default function PlayerSearchInput({
   teamId,
@@ -26,7 +31,19 @@ export default function PlayerSearchInput({
   const [loading, setLoading] = useState(false);
 
   // ids ya elegidos para filtrar resultados
-  const selectedIds = useMemo(() => new Set(selected.map((s) => s.id)), [selected]);
+  const selectedIds = useMemo(
+    () =>
+      new Set(
+        selected?.kind === 'player' ? [selected.candidate.id] : []
+      ),
+    [selected]
+  );
+  const normalizedEmail = q.trim().toLowerCase();
+  const canInviteByEmail =
+    !loading &&
+    results.length === 0 &&
+    normalizedEmail.length <= 254 &&
+    EMAIL_PATTERN.test(normalizedEmail);
 
   useEffect(() => {
     let canceled = false;
@@ -75,9 +92,34 @@ export default function PlayerSearchInput({
       {q.trim().length >= minChars && (
         <div className="mt-2 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-[0_16px_32px_-24px_rgba(15,23,42,0.35)]">
           {loading && <div className="p-3 text-sm text-stone-500">Buscando…</div>}
-          {!loading && results.length === 0 && (
+          {!loading && results.length === 0 && !canInviteByEmail && (
             <div className="p-3 text-sm text-stone-500">Sin resultados</div>
           )}
+          {canInviteByEmail ? (
+            <button
+              type="button"
+              onClick={() => {
+                onSelect({ kind: 'email', email: normalizedEmail });
+                setQ('');
+              }}
+              className="group flex min-h-[4.25rem] w-full items-center gap-3 px-3.5 py-2.5 text-left transition hover:bg-mulberry/[0.035] focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-inset focus-visible:ring-mulberry/15"
+            >
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-mulberry/10 bg-mulberry/10 text-mulberry">
+                <UserPlusIcon aria-hidden="true" className="h-5 w-5" />
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-semibold text-slate-900">
+                  {normalizedEmail}
+                </span>
+                <span className="mt-0.5 block text-xs text-slate-500">
+                  Puede crear su cuenta después de recibir el correo
+                </span>
+              </span>
+              <span className="inline-flex shrink-0 items-center rounded-full border border-mulberry/10 bg-mulberry/[0.07] px-2.5 py-1.5 text-xs font-semibold text-mulberry transition group-hover:bg-mulberry group-hover:text-white">
+                Convocar
+              </span>
+            </button>
+          ) : null}
           {!loading &&
             results.map((p) => {
               const canInvite = p.status === 'available';
@@ -94,7 +136,7 @@ export default function PlayerSearchInput({
                 type="button"
                 disabled={!canInvite}
                 onClick={() => {
-                  onSelect(p);
+                  onSelect({ kind: 'player', candidate: p });
                   setQ(''); // limpia el input después de elegir
                 }}
                 className="group flex min-h-[4.25rem] w-full items-center gap-3 border-b border-slate-100 px-3.5 py-2.5 text-left transition last:border-b-0 hover:bg-mulberry/[0.035] focus-visible:relative focus-visible:z-10 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-inset focus-visible:ring-mulberry/15 disabled:cursor-not-allowed disabled:bg-slate-50/70"
@@ -140,24 +182,23 @@ export default function PlayerSearchInput({
       )}
 
       {/* chips seleccionados (opcional mostrar aquí) */}
-      {selected.length > 0 && (
+      {selected ? (
         <div className="mt-3" aria-live="polite">
-          {selected.map((p) => (
-            <div
-              key={p.id}
-              className="flex items-center gap-3 rounded-2xl border border-mulberry/15 bg-mulberry/[0.045] px-3.5 py-3"
-            >
-              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-mulberry text-white shadow-sm">
-                <CheckIcon aria-hidden="true" className="h-4 w-4 stroke-2" />
+          <div className="flex items-center gap-3 rounded-2xl border border-mulberry/15 bg-mulberry/[0.045] px-3.5 py-3">
+            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-mulberry text-white shadow-sm">
+              <CheckIcon aria-hidden="true" className="h-4 w-4 stroke-2" />
+            </span>
+            <span className="min-w-0">
+              <span className="block text-xs font-medium text-slate-500">Lista para convocar</span>
+              <span className="block truncate text-sm font-semibold text-slate-900">
+                {selected.kind === 'player'
+                  ? `@${selected.candidate.username}`
+                  : selected.email}
               </span>
-              <span className="min-w-0">
-                <span className="block text-xs font-medium text-slate-500">Lista para convocar</span>
-                <span className="block truncate text-sm font-semibold text-slate-900">@{p.username}</span>
-              </span>
-            </div>
-          ))}
+            </span>
+          </div>
         </div>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/src/modules/teams/ui/TeamInvitationManager.tsx
+++ b/src/modules/teams/ui/TeamInvitationManager.tsx
@@ -9,12 +9,13 @@ import {
 } from '@heroicons/react/24/outline';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
-import type { TeamInvitationCandidate } from '@modules/teams/model/types';
+import type { TeamInvitationSelection } from '@modules/teams/model/types';
 import PlayerSearchInput from './PlayerSearchInput';
 
 type CreatedInvitation = {
   id: number;
   username: string | null;
+  email: string | null;
   emailDeliveryStatus: 'sent' | 'failed';
 };
 
@@ -27,7 +28,7 @@ type CreateInvitationResponse = {
 export default function TeamInvitationManager({ teamId }: { teamId: number }) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
-  const [selected, setSelected] = useState<TeamInvitationCandidate[]>([]);
+  const [selected, setSelected] = useState<TeamInvitationSelection | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<CreateInvitationResponse | null>(null);
@@ -35,14 +36,13 @@ export default function TeamInvitationManager({ teamId }: { teamId: number }) {
   function close() {
     if (submitting) return;
     setOpen(false);
-    setSelected([]);
+    setSelected(null);
     setError(null);
     setResult(null);
   }
 
   async function submit() {
-    const candidate = selected[0];
-    if (!candidate || submitting) return;
+    if (!selected || submitting) return;
 
     setSubmitting(true);
     setError(null);
@@ -51,7 +51,11 @@ export default function TeamInvitationManager({ teamId }: { teamId: number }) {
       const response = await fetch(`/api/teams/${teamId}/invitations`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ candidateUserId: candidate.id }),
+        body: JSON.stringify(
+          selected.kind === 'player'
+            ? { candidateUserId: selected.candidate.id }
+            : { email: selected.email }
+        ),
       });
       const payload = (await response.json().catch(() => ({}))) as CreateInvitationResponse;
 
@@ -60,7 +64,7 @@ export default function TeamInvitationManager({ teamId }: { teamId: number }) {
       }
 
       setResult(payload);
-      setSelected([]);
+      setSelected(null);
       router.refresh();
     } catch (submitError) {
       setError(
@@ -80,24 +84,20 @@ export default function TeamInvitationManager({ teamId }: { teamId: number }) {
         onClick={() => setOpen(true)}
         aria-haspopup="dialog"
         aria-expanded={open}
-        className="group relative inline-flex min-h-[3.25rem] w-full items-center gap-3 overflow-hidden rounded-2xl border border-white/15 bg-[linear-gradient(135deg,#54086F_0%,#76288C_62%,#8B3B8E_100%)] px-3 py-2.5 text-left text-white shadow-[0_14px_30px_-16px_rgba(84,8,111,0.85)] transition duration-200 hover:-translate-y-0.5 hover:shadow-[0_18px_34px_-16px_rgba(84,8,111,0.95)] active:translate-y-0 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-mulberry/20 sm:w-auto sm:min-w-[15rem]"
+        className="group inline-flex min-h-12 w-full items-center gap-3 rounded-xl border border-mulberry bg-mulberry px-4 py-2.5 text-left text-white shadow-sm transition hover:border-[#430659] hover:bg-[#430659] focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-mulberry/20 sm:w-auto sm:min-w-[14rem]"
       >
-        <span
-          aria-hidden="true"
-          className="absolute -right-7 -top-10 h-24 w-24 rounded-full bg-primary/25 blur-2xl transition duration-300 group-hover:scale-125"
-        />
-        <span className="relative flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-white/15 bg-white/10 shadow-inner shadow-white/10">
+        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white/10">
           <UserPlusIcon aria-hidden="true" className="h-5 w-5" />
         </span>
-        <span className="relative min-w-0 flex-1">
-          <span aria-hidden="true" className="block text-[0.65rem] font-semibold uppercase tracking-[0.16em] text-white/65">
-            Sumar al plantel
+        <span className="min-w-0 flex-1">
+          <span className="block text-sm font-semibold leading-tight">Convocar jugadoras</span>
+          <span className="mt-0.5 block text-xs leading-tight text-white/70">
+            Por usuario o correo
           </span>
-          <span className="mt-0.5 block text-sm font-semibold leading-none">Convocar jugadoras</span>
         </span>
         <ArrowRightIcon
           aria-hidden="true"
-          className="relative h-4 w-4 shrink-0 text-white/70 transition-transform duration-200 group-hover:translate-x-0.5 group-hover:text-white"
+          className="h-4 w-4 shrink-0 text-white/70 transition-transform group-hover:translate-x-0.5 group-hover:text-white"
         />
       </button>
 
@@ -121,7 +121,8 @@ export default function TeamInvitationManager({ teamId }: { teamId: number }) {
                   Convocar jugadora
                 </h2>
                 <p className="mt-1 text-sm leading-6 text-slate-500">
-                  Busca una cuenta existente por @username o por su email exacto.
+                  Busca por @username o escribe un email. Si aún no tiene cuenta,
+                  podrá crearla desde la convocatoria.
                 </p>
               </div>
               <button
@@ -138,8 +139,8 @@ export default function TeamInvitationManager({ teamId }: { teamId: number }) {
               <PlayerSearchInput
                 teamId={teamId}
                 selected={selected}
-                onSelect={(candidate) => {
-                  setSelected([candidate]);
+                onSelect={(selection) => {
+                  setSelected(selection);
                   setError(null);
                   setResult(null);
                 }}
@@ -152,7 +153,10 @@ export default function TeamInvitationManager({ teamId }: { teamId: number }) {
                   <CheckCircleIcon aria-hidden="true" className="h-5 w-5 shrink-0" />
                   <div>
                     <p className="font-semibold">
-                      Convocatoria enviada a @{result.invitation.username}
+                      Convocatoria enviada a{' '}
+                      {result.invitation.username
+                        ? `@${result.invitation.username}`
+                        : result.invitation.email}
                     </p>
                     {result.warning ? <p className="mt-1 text-amber-800">{result.warning}</p> : null}
                   </div>
@@ -179,8 +183,8 @@ export default function TeamInvitationManager({ teamId }: { teamId: number }) {
                 <button
                   type="button"
                   onClick={submit}
-                  disabled={!selected[0] || submitting}
-                  className="group inline-flex h-12 items-center justify-center gap-2 rounded-xl bg-[linear-gradient(135deg,#54086F_0%,#76288C_100%)] px-5 text-sm font-semibold text-white shadow-[0_12px_24px_-14px_rgba(84,8,111,0.9)] transition hover:-translate-y-0.5 hover:shadow-[0_16px_28px_-14px_rgba(84,8,111,0.95)] active:translate-y-0 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-mulberry/20 disabled:cursor-not-allowed disabled:opacity-45 disabled:shadow-none disabled:hover:translate-y-0"
+                  disabled={!selected || submitting}
+                  className="group inline-flex h-12 items-center justify-center gap-2 rounded-xl border border-mulberry bg-mulberry px-5 text-sm font-semibold text-white shadow-sm transition hover:border-[#430659] hover:bg-[#430659] focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-mulberry/20 disabled:cursor-not-allowed disabled:opacity-45"
                 >
                   <PaperAirplaneIcon
                     aria-hidden="true"

--- a/src/modules/teams/ui/TeamPublicProfilePage.tsx
+++ b/src/modules/teams/ui/TeamPublicProfilePage.tsx
@@ -118,21 +118,21 @@ export default function TeamPublicProfilePage({
 
   return (
     <main className="site-shell w-full py-5 sm:py-8">
-      <section className="overflow-hidden rounded-3xl border border-white/80 bg-white shadow-[0_20px_60px_rgba(84,8,111,0.10)]">
-        <div className="relative h-36 overflow-hidden bg-[linear-gradient(125deg,#54086F_0%,#7B2A91_50%,#F0815B_135%)] sm:h-44">
-          <div aria-hidden="true" className="absolute -left-14 -top-20 h-52 w-52 rounded-full border-[42px] border-white/10" />
-          <div aria-hidden="true" className="absolute -bottom-24 right-28 h-52 w-52 rounded-full bg-white/10 blur-2xl" />
-          <div className="absolute right-4 top-4 sm:right-6 sm:top-6">
+      <section className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm">
+        <div className="bg-[#F8F4FA] px-5 py-5 sm:px-8 sm:py-7">
+          <div className="flex items-center justify-between gap-3">
+            <p className="whitespace-nowrap text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-mulberry/70 sm:text-xs sm:tracking-[0.16em]">
+              Perfil del equipo
+            </p>
             <PublicProfileShareButton
               title={`${team.name} en Peloteras`}
               text={`Conoce el perfil de ${team.name} en Peloteras.`}
+              compactOnMobile
             />
           </div>
-        </div>
 
-        <div className="relative px-5 pb-7 sm:px-8 sm:pb-9">
-          <div className="-mt-14 flex flex-col gap-5 sm:-mt-16 sm:flex-row sm:items-start">
-            <div className="flex h-28 w-28 shrink-0 items-center justify-center overflow-hidden rounded-3xl border-4 border-white bg-[#F7F1F9] text-3xl font-bold text-mulberry shadow-lg sm:h-32 sm:w-32">
+          <div className="mt-5 flex flex-col gap-5 sm:flex-row sm:items-center sm:gap-6">
+            <div className="flex h-28 w-28 shrink-0 items-center justify-center overflow-hidden rounded-3xl border border-mulberry/10 bg-white text-3xl font-bold text-mulberry shadow-sm sm:h-32 sm:w-32">
               {team.avatar_url ? (
                 <img src={team.avatar_url} alt={`Foto de ${team.name}`} className="h-full w-full object-cover" />
               ) : (
@@ -140,7 +140,7 @@ export default function TeamPublicProfilePage({
               )}
             </div>
 
-            <div className="min-w-0 flex-1 sm:pt-16">
+            <div className="min-w-0 flex-1">
               <p className="text-sm font-semibold text-mulberry">@{team.slug}</p>
               <h1 className="mt-1 break-words font-eastman-extrabold text-3xl font-extrabold tracking-tight text-slate-950 sm:text-4xl">
                 {team.name}
@@ -148,23 +148,22 @@ export default function TeamPublicProfilePage({
               <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
                 Equipo de fútbol en Peloteras. Conoce a sus integrantes y encuentra sus perfiles públicos.
               </p>
-              <div className="mt-4 flex flex-wrap gap-2">
-                <span className="inline-flex items-center gap-1.5 rounded-full bg-mulberry/8 px-3 py-1.5 text-xs font-semibold text-mulberry">
-                  <UserGroupIcon aria-hidden="true" className="h-4 w-4" />
-                  {members.length} {members.length === 1 ? 'jugadora' : 'jugadoras'}
-                </span>
-                <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-50 px-3 py-1.5 text-xs font-semibold text-emerald-700">
-                  <CheckCircleIcon aria-hidden="true" className="h-4 w-4" />
-                  Equipo activo
-                </span>
-              </div>
-              {canManageInvitations ? (
-                <div className="mt-5">
-                  <TeamInvitationManager teamId={team.id} />
-                </div>
-              ) : null}
             </div>
           </div>
+        </div>
+
+        <div className="flex flex-col gap-4 border-t border-slate-200 px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-8">
+          <div className="flex flex-wrap gap-2">
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-mulberry/10 bg-mulberry/[0.05] px-3 py-1.5 text-xs font-semibold text-mulberry">
+              <UserGroupIcon aria-hidden="true" className="h-4 w-4" />
+              {members.length} {members.length === 1 ? 'jugadora' : 'jugadoras'}
+            </span>
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-100 bg-emerald-50 px-3 py-1.5 text-xs font-semibold text-emerald-700">
+              <CheckCircleIcon aria-hidden="true" className="h-4 w-4" />
+              Equipo activo
+            </span>
+          </div>
+          {canManageInvitations ? <TeamInvitationManager teamId={team.id} /> : null}
         </div>
       </section>
 

--- a/src/shared/ui/PublicProfileShareButton.tsx
+++ b/src/shared/ui/PublicProfileShareButton.tsx
@@ -6,9 +6,14 @@ import { useState } from 'react';
 type Props = {
   title: string;
   text: string;
+  compactOnMobile?: boolean;
 };
 
-export default function PublicProfileShareButton({ title, text }: Props) {
+export default function PublicProfileShareButton({
+  title,
+  text,
+  compactOnMobile = false,
+}: Props) {
   const [copied, setCopied] = useState(false);
 
   async function shareProfile() {
@@ -36,14 +41,27 @@ export default function PublicProfileShareButton({ title, text }: Props) {
     <button
       type="button"
       onClick={shareProfile}
-      className="inline-flex h-10 items-center justify-center gap-2 rounded-full border border-white/70 bg-white px-4 text-sm font-semibold text-mulberry shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-white/50"
+      className="inline-flex h-10 items-center justify-center gap-2 whitespace-nowrap rounded-full border border-white/70 bg-white px-4 text-sm font-semibold text-mulberry shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-white/50"
     >
       {copied ? (
         <CheckIcon aria-hidden="true" className="h-4 w-4" />
       ) : (
         <ShareIcon aria-hidden="true" className="h-4 w-4" />
       )}
-      <span aria-live="polite">{copied ? 'Enlace copiado' : 'Compartir perfil'}</span>
+      <span aria-live="polite">
+        {compactOnMobile ? (
+          <>
+            <span className="sm:hidden">{copied ? 'Copiado' : 'Compartir'}</span>
+            <span className="hidden sm:inline">
+              {copied ? 'Enlace copiado' : 'Compartir perfil'}
+            </span>
+          </>
+        ) : copied ? (
+          'Enlace copiado'
+        ) : (
+          'Compartir perfil'
+        )}
+      </span>
     </button>
   );
 }

--- a/supabase/migrations/20260729160000_team_external_email_invitations.sql
+++ b/supabase/migrations/20260729160000_team_external_email_invitations.sql
@@ -1,0 +1,221 @@
+-- Allow captains to invite a player by email before she has a Peloteras account.
+-- The invitation is attached to the matching account only after the recipient
+-- follows its private token while authenticated with that email address.
+
+CREATE OR REPLACE FUNCTION public.create_team_invitation(
+  p_team_id BIGINT,
+  p_delivery_method TEXT DEFAULT 'username',
+  p_invitee_user_id UUID DEFAULT NULL,
+  p_invitee_email TEXT DEFAULT NULL,
+  p_invitee_username TEXT DEFAULT NULL,
+  p_expires_at TIMESTAMPTZ DEFAULT NULL,
+  p_metadata JSONB DEFAULT '{}'::jsonb
+)
+RETURNS SETOF public.team_invitation
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+  v_delivery_method TEXT := lower(btrim(COALESCE(p_delivery_method, 'username')));
+  v_invitee_email TEXT := lower(NULLIF(btrim(COALESCE(p_invitee_email, '')), ''));
+  v_invitee_username TEXT := lower(NULLIF(btrim(COALESCE(p_invitee_username, '')), ''));
+  v_invitee_user_id UUID := p_invitee_user_id;
+  v_source TEXT;
+  v_invitation public.team_invitation%ROWTYPE;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Authentication required' USING ERRCODE = '28000';
+  END IF;
+
+  IF NOT public.is_active_team_captain(p_team_id, v_user_id) THEN
+    RAISE EXCEPTION 'Only an active team captain can create invitations'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_delivery_method NOT IN ('username', 'email', 'link') THEN
+    RAISE EXCEPTION 'Invalid invitation delivery method' USING ERRCODE = '23514';
+  END IF;
+
+  v_source := CASE
+    WHEN v_delivery_method = 'link' THEN 'team_link'
+    ELSE 'captain_search'
+  END;
+
+  IF v_delivery_method = 'username'
+    AND v_invitee_username IS NULL
+    AND v_invitee_user_id IS NULL THEN
+    RAISE EXCEPTION 'Username invitation requires a username'
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF v_delivery_method = 'email' AND v_invitee_email IS NULL THEN
+    RAISE EXCEPTION 'Email invitation requires an email'
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF v_delivery_method = 'username' AND v_invitee_user_id IS NULL THEN
+    SELECT profile.user
+    INTO v_invitee_user_id
+    FROM public.profile profile
+    WHERE lower(btrim(profile.username)) = v_invitee_username
+    LIMIT 1;
+  END IF;
+
+  IF v_delivery_method = 'email' AND v_invitee_user_id IS NULL THEN
+    SELECT auth_user.id
+    INTO v_invitee_user_id
+    FROM auth.users auth_user
+    WHERE lower(btrim(auth_user.email)) = v_invitee_email
+    LIMIT 1;
+  END IF;
+
+  -- Username and legacy link invitations still require a known account. Email
+  -- invitations intentionally keep a null user id until the recipient signs up.
+  IF v_delivery_method <> 'email' AND v_invitee_user_id IS NULL THEN
+    RAISE EXCEPTION 'Player is not available for invitation'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_invitee_user_id = v_user_id THEN
+    RAISE EXCEPTION 'Captain cannot invite herself' USING ERRCODE = '23514';
+  END IF;
+
+  IF v_invitee_user_id IS NOT NULL THEN
+    SELECT lower(NULLIF(btrim(profile.username), ''))
+    INTO v_invitee_username
+    FROM public.profile profile
+    WHERE profile.user = v_invitee_user_id
+    ORDER BY profile.id DESC
+    LIMIT 1;
+
+    IF v_delivery_method = 'username' AND v_invitee_username IS NULL THEN
+      RAISE EXCEPTION 'Player is not available for invitation'
+        USING ERRCODE = 'P0002';
+    END IF;
+
+    SELECT lower(NULLIF(btrim(auth_user.email), ''))
+    INTO v_invitee_email
+    FROM auth.users auth_user
+    WHERE auth_user.id = v_invitee_user_id;
+  END IF;
+
+  INSERT INTO public.team_invitation (
+    team_id,
+    invited_by_user_id,
+    invitee_user_id,
+    invitee_email,
+    invitee_username,
+    delivery_method,
+    source,
+    expires_at,
+    email_delivery_status,
+    metadata
+  )
+  VALUES (
+    p_team_id,
+    v_user_id,
+    v_invitee_user_id,
+    v_invitee_email,
+    v_invitee_username,
+    v_delivery_method,
+    v_source,
+    COALESCE(p_expires_at, now() + interval '14 days'),
+    CASE WHEN v_invitee_email IS NULL THEN 'not_applicable' ELSE 'pending' END,
+    COALESCE(p_metadata, '{}'::jsonb)
+  )
+  RETURNING * INTO v_invitation;
+
+  RETURN QUERY
+  SELECT created_invitation.*
+  FROM public.team_invitation created_invitation
+  WHERE created_invitation.id = v_invitation.id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.claim_team_invitation_by_token(
+  p_token UUID
+)
+RETURNS SETOF public.team_invitation
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+  v_user_email TEXT;
+  v_username TEXT;
+  v_invitation public.team_invitation%ROWTYPE;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Authentication required' USING ERRCODE = '28000';
+  END IF;
+
+  SELECT lower(NULLIF(btrim(auth_user.email), ''))
+  INTO v_user_email
+  FROM auth.users auth_user
+  WHERE auth_user.id = v_user_id;
+
+  SELECT invitation.*
+  INTO v_invitation
+  FROM public.team_invitation invitation
+  WHERE invitation.invitation_token = p_token
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Invitation not found' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_invitation.invitee_user_id IS NOT NULL THEN
+    IF v_invitation.invitee_user_id IS DISTINCT FROM v_user_id THEN
+      RAISE EXCEPTION 'Invitation not found' USING ERRCODE = 'P0002';
+    END IF;
+
+    RETURN QUERY
+    SELECT invitation.*
+    FROM public.team_invitation invitation
+    WHERE invitation.id = v_invitation.id;
+    RETURN;
+  END IF;
+
+  IF v_invitation.delivery_method <> 'email'
+    OR v_user_email IS NULL
+    OR v_invitation.invitee_email IS NULL
+    OR v_user_email IS DISTINCT FROM lower(btrim(v_invitation.invitee_email)) THEN
+    RAISE EXCEPTION 'Invitation not found' USING ERRCODE = 'P0002';
+  END IF;
+
+  SELECT lower(NULLIF(btrim(profile.username), ''))
+  INTO v_username
+  FROM public.profile profile
+  WHERE profile.user = v_user_id
+  ORDER BY profile.id DESC
+  LIMIT 1;
+
+  UPDATE public.team_invitation invitation
+  SET
+    invitee_user_id = v_user_id,
+    invitee_username = COALESCE(invitation.invitee_username, v_username)
+  WHERE invitation.id = v_invitation.id
+  RETURNING invitation.* INTO v_invitation;
+
+  RETURN QUERY SELECT v_invitation.*;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.create_team_invitation(BIGINT, TEXT, UUID, TEXT, TEXT, TIMESTAMPTZ, JSONB)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.create_team_invitation(BIGINT, TEXT, UUID, TEXT, TEXT, TIMESTAMPTZ, JSONB)
+  TO authenticated;
+
+REVOKE ALL ON FUNCTION public.claim_team_invitation_by_token(UUID)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.claim_team_invitation_by_token(UUID)
+  TO authenticated;
+
+COMMENT ON FUNCTION public.create_team_invitation(BIGINT, TEXT, UUID, TEXT, TEXT, TIMESTAMPTZ, JSONB) IS
+  'Creates nominated invitations; an email target may be claimed later if no matching account exists yet.';
+
+COMMENT ON FUNCTION public.claim_team_invitation_by_token(UUID) IS
+  'Claims an email invitation only when its private token and the authenticated account email both match.';

--- a/supabase/tests/team_invitation_external_email.test.sql
+++ b/supabase/tests/team_invitation_external_email.test.sql
@@ -1,0 +1,218 @@
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
+SELECT extensions.plan(10);
+
+INSERT INTO auth.users (
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  created_at,
+  updated_at
+)
+VALUES (
+  '10000000-0000-0000-0000-000000000701',
+  'authenticated',
+  'authenticated',
+  'external-invite-captain@example.test',
+  crypt('password', gen_salt('bf')),
+  now(),
+  now(),
+  now()
+);
+
+INSERT INTO public.team (name, slug, created_by_user_id)
+VALUES (
+  'External Email FC',
+  'external-email-fc',
+  '10000000-0000-0000-0000-000000000701'
+);
+
+INSERT INTO public.team_member (team_id, user_id, role, status, joined_at)
+SELECT id, '10000000-0000-0000-0000-000000000701', 'captain', 'active', now()
+FROM public.team
+WHERE slug = 'external-email-fc';
+
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub', '10000000-0000-0000-0000-000000000701', true);
+SELECT set_config('request.jwt.claim.role', 'authenticated', true);
+
+SELECT set_config(
+  'test.external_invitation_id',
+  (
+    SELECT id::TEXT
+    FROM public.create_team_invitation(
+      (SELECT id FROM public.team WHERE slug = 'external-email-fc'),
+      'email',
+      NULL,
+      '  NEW-PLAYER@EXAMPLE.TEST  '
+    )
+  ),
+  true
+);
+
+SELECT set_config(
+  'test.external_invitation_token',
+  (
+    SELECT invitation_token::TEXT
+    FROM public.team_invitation
+    WHERE id = current_setting('test.external_invitation_id')::BIGINT
+  ),
+  true
+);
+
+SELECT extensions.is(
+  (
+    SELECT invitee_user_id
+    FROM public.team_invitation
+    WHERE id = current_setting('test.external_invitation_id')::BIGINT
+  ),
+  NULL::UUID,
+  'an invitation can be created before the email has an account'
+);
+
+SELECT extensions.is(
+  (
+    SELECT invitee_email
+    FROM public.team_invitation
+    WHERE id = current_setting('test.external_invitation_id')::BIGINT
+  ),
+  'new-player@example.test',
+  'the external email is normalized'
+);
+
+SELECT extensions.is(
+  (
+    SELECT email_delivery_status
+    FROM public.team_invitation
+    WHERE id = current_setting('test.external_invitation_id')::BIGINT
+  ),
+  'pending',
+  'the external invitation is ready for email delivery'
+);
+
+RESET ROLE;
+
+INSERT INTO auth.users (
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  created_at,
+  updated_at
+)
+VALUES
+  (
+    '10000000-0000-0000-0000-000000000702',
+    'authenticated',
+    'authenticated',
+    'wrong-player@example.test',
+    crypt('password', gen_salt('bf')),
+    now(),
+    now(),
+    now()
+  ),
+  (
+    '10000000-0000-0000-0000-000000000703',
+    'authenticated',
+    'authenticated',
+    'new-player@example.test',
+    crypt('password', gen_salt('bf')),
+    now(),
+    now(),
+    now()
+  );
+
+INSERT INTO public.profile ("user", username, onboarding_step, is_profile_complete)
+VALUES ('10000000-0000-0000-0000-000000000703', 'new_player', 3, true);
+
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub', '10000000-0000-0000-0000-000000000702', true);
+SELECT set_config('request.jwt.claim.role', 'authenticated', true);
+
+SELECT extensions.throws_ok(
+  format(
+    'SELECT * FROM public.claim_team_invitation_by_token(%L::UUID)',
+    current_setting('test.external_invitation_token')
+  ),
+  'P0002',
+  NULL,
+  'a different account cannot claim the private invitation token'
+);
+
+SELECT set_config('request.jwt.claim.sub', '10000000-0000-0000-0000-000000000703', true);
+
+SELECT extensions.is(
+  (
+    SELECT invitee_user_id
+    FROM public.claim_team_invitation_by_token(
+      current_setting('test.external_invitation_token')::UUID
+    )
+  ),
+  '10000000-0000-0000-0000-000000000703'::UUID,
+  'the account with the invited email can claim it'
+);
+
+SELECT extensions.is(
+  (
+    SELECT invitee_username
+    FROM public.team_invitation
+    WHERE id = current_setting('test.external_invitation_id')::BIGINT
+  ),
+  'new_player',
+  'claiming attaches the new profile username'
+);
+
+SELECT extensions.is(
+  (
+    SELECT invitee_user_id
+    FROM public.claim_team_invitation_by_token(
+      current_setting('test.external_invitation_token')::UUID
+    )
+  ),
+  '10000000-0000-0000-0000-000000000703'::UUID,
+  'claiming the same invitation twice is idempotent'
+);
+
+SELECT extensions.is(
+  (
+    SELECT status
+    FROM public.respond_to_team_invitation(
+      current_setting('test.external_invitation_id')::BIGINT,
+      'accepted'
+    )
+  ),
+  'accepted',
+  'the new account can accept the claimed invitation'
+);
+
+SELECT extensions.is(
+  (
+    SELECT status
+    FROM public.team_member
+    WHERE team_id = (SELECT id FROM public.team WHERE slug = 'external-email-fc')
+      AND user_id = '10000000-0000-0000-0000-000000000703'
+  ),
+  'active',
+  'accepting creates the active membership'
+);
+
+SELECT extensions.is(
+  (
+    SELECT role
+    FROM public.team_member
+    WHERE team_id = (SELECT id FROM public.team WHERE slug = 'external-email-fc')
+      AND user_id = '10000000-0000-0000-0000-000000000703'
+  ),
+  'player',
+  'the claimed membership has player role'
+);
+
+SELECT * FROM extensions.finish();
+
+ROLLBACK;


### PR DESCRIPTION
## Resumen
- incorpora perfiles públicos y administración de equipos, convocatorias nominadas y por enlace, y registro grupal a eventos
- permite convocar por email aunque la destinataria todavía no tenga cuenta, asociando la invitación de forma segura cuando se registra con ese correo
- simplifica el perfil público del equipo con superficies planas, acciones alineadas y comportamiento responsive sin overflow

## Validación
- `npm run typecheck`
- `npm run build`
- revisión visual en 390 px y 1440 px sin overflow horizontal ni errores de consola
- se agregó cobertura pgTAP para convocatorias por email externo; no se ejecutó localmente porque Docker/Supabase local no estaba disponible